### PR TITLE
feat: add paginated review API (get_pr_content, get_local_content)

### DIFF
--- a/.github/CodebaseUnderstanding.md
+++ b/.github/CodebaseUnderstanding.md
@@ -57,7 +57,7 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | `REBUSS.Pure.Core\IScmClient.cs` | Unified SCM client contract | `IScmClient` (extends `IPullRequestDataProvider` + `IFileContentDataProvider`), `IPullRequestDataProvider`, `IFileContentDataProvider` |
 | `REBUSS.Pure.Core\IWorkspaceRootProvider.cs` | Workspace/repository root resolution contract | `IWorkspaceRootProvider` � `SetCliRepositoryPath`, `SetRoots`, `GetRootUris`, `ResolveRepositoryRoot` |
 | `REBUSS.Pure.Core\IContextBudgetResolver.cs` | Context window budget resolution contract | `IContextBudgetResolver` — `Resolve(int?, string?)` → `BudgetResolutionResult` |
-| `REBUSS.Pure.Core\ITokenEstimator.cs` | Token estimation contract (schema-independent) | `ITokenEstimator` — `Estimate(string, int)` → `TokenEstimationResult` |
+| `REBUSS.Pure.Core\ITokenEstimator.cs` | Token estimation contract (schema-independent) | `ITokenEstimator` — `Estimate(string, int)` → `TokenEstimationResult`, `EstimateFromStats(int, int)` → `int` |
 | `REBUSS.Pure.Core\IResponsePacker.cs` | Response packing contract | `IResponsePacker` — `Pack(IReadOnlyList<PackingCandidate>, int)` → `PackingDecision` |
 | `REBUSS.Pure.Core\IPageAllocator.cs` | Deterministic page allocation contract (Feature 004) | `IPageAllocator` — `Allocate(sortedCandidates, safeBudgetTokens)` → `PageAllocation` |
 | `REBUSS.Pure.Core\IPageReferenceCodec.cs` | Base64url page reference encode/decode contract (Feature 004) | `IPageReferenceCodec` — `Encode(PageReferenceData)` → `string`, `TryDecode(string)` → `PageReferenceData?` |
@@ -211,7 +211,7 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 |---|---|---|
 | `REBUSS.Pure\Services\ContextWindow\ContextWindowOptions.cs` | `IOptions<T>` configuration: safety margin, chars-per-token, default budget, min/max guardrails, model registry | — |
 | `REBUSS.Pure\Services\ContextWindow\ContextBudgetResolver.cs` | Three-tier budget resolution: explicit → registry → default, with guardrails and warnings | `IContextBudgetResolver`, `IOptions<ContextWindowOptions>`, `ILogger<ContextBudgetResolver>` |
-| `REBUSS.Pure\Services\ContextWindow\TokenEstimator.cs` | Character-count token estimation heuristic, schema-independent | `ITokenEstimator`, `IOptions<ContextWindowOptions>`, `ILogger<TokenEstimator>` |
+| `REBUSS.Pure\Services\ContextWindow\TokenEstimator.cs` | Character-count token estimation heuristic, schema-independent; stat-based estimation (`EstimateFromStats`) using `AvgTokensPerLine=15`, `PerFileOverhead=50` | `ITokenEstimator`, `IOptions<ContextWindowOptions>`, `ILogger<TokenEstimator>` |
 
 ### Response Packing (REBUSS.Pure\Services)
 
@@ -235,7 +235,9 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 |---|---|---|
 | `REBUSS.Pure\Tools\GetPullRequestDiffToolHandler.cs` | `[McpServerToolType]` `get_pr_diff` — returns structured JSON with per-file hunks; F004 integration: dual F003/F004 paths, pageReference resume, staleness detection, pageNumber access; prNumber now optional when pageReference is provided; SDK attribute-based registration (`[McpServerTool]`/`[Description]`), throws `McpException` for errors | `IPullRequestDataProvider`, `IPageAllocator`, `IPageReferenceCodec`, `StructuredDiffResult` models, `PaginationMetadataResult`, `StalenessWarningResult` |
 | `REBUSS.Pure\Tools\GetFileDiffToolHandler.cs` | `[McpServerToolType]` `get_file_diff` — returns structured JSON for a single file; SDK attribute-based registration (`[McpServerTool]`/`[Description]`), throws `McpException`/`ArgumentException` for errors | `IPullRequestDataProvider`, `StructuredDiffResult` models |
-| `REBUSS.Pure\Tools\GetPullRequestMetadataToolHandler.cs` | `[McpServerToolType]` `get_pr_metadata` — returns PR metadata JSON; SDK attribute-based registration (`[McpServerTool]`/`[Description]`), throws `McpException`/`ArgumentException` for errors | `IPullRequestDataProvider`, `PullRequestMetadataResult` models |
+| `REBUSS.Pure\Tools\GetPullRequestMetadataToolHandler.cs` | `[McpServerToolType]` `get_pr_metadata` — returns PR metadata JSON; extended with optional `modelName`/`maxTokens` params to compute `contentPaging` (page allocation via stat-based estimation); SDK attribute-based registration (`[McpServerTool]`/`[Description]`), throws `McpException` for errors | `IPullRequestDataProvider`, `IContextBudgetResolver`, `ITokenEstimator`, `IFileClassifier`, `IPageAllocator`, `PullRequestMetadataResult` models |
+| `REBUSS.Pure\Tools\GetPullRequestContentToolHandler.cs` | `[McpServerToolType]` `get_pr_content` — returns paginated diff content for a single page of a PR; stat-based page allocation, fetches full diff then filters to page files; SDK attribute-based registration | `IPullRequestDataProvider`, `IContextBudgetResolver`, `ITokenEstimator`, `IFileClassifier`, `IPageAllocator`, `PullRequestContentPageResult`, `ContentPageSummary` models |
+| `REBUSS.Pure\Tools\GetLocalContentToolHandler.cs` | `[McpServerToolType]` `get_local_content` — returns paginated diff content for a single page of local changes; stat-based page allocation, per-file diff fetch (only page files); SDK attribute-based registration | `ILocalReviewProvider`, `IContextBudgetResolver`, `ITokenEstimator`, `IFileClassifier`, `IPageAllocator`, `LocalContentPageResult`, `ContentPageSummary` models |
 | `REBUSS.Pure\Tools\GetPullRequestFilesToolHandler.cs` | `[McpServerToolType]` `get_pr_files` — returns classified file list JSON; F004 integration: same pagination pattern as get_pr_diff; prNumber now optional when pageReference is provided; SDK attribute-based registration, throws `McpException` for errors | `IPullRequestDataProvider`, `IPageAllocator`, `IPageReferenceCodec`, `PullRequestFilesResult` models, `PaginationMetadataResult`, `StalenessWarningResult` |
 | `REBUSS.Pure\Tools\GetFileContentAtRefToolHandler.cs` | `[McpServerToolType]` `get_file_content_at_ref` — returns file content JSON; SDK attribute-based registration (`[McpServerTool]`/`[Description]`), throws `McpException`/`ArgumentException` for errors | `IFileContentDataProvider`, `FileContentAtRefResult` model |
 | `REBUSS.Pure\Tools\GetLocalChangesFilesToolHandler.cs` | `[McpServerToolType]` `get_local_files` — lists locally changed files with classification; F004 integration: pagination support but no staleness (null fingerprint); SDK attribute-based registration, throws `McpException` for errors | `ILocalReviewProvider`, `IPageAllocator`, `IPageReferenceCodec`, `LocalReviewFilesResult` model, `PaginationMetadataResult` |
@@ -246,7 +248,10 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | File | Role |
 |---|---|
 | `REBUSS.Pure\Tools\Models\StructuredDiffResult.cs` | `StructuredDiffResult`, `StructuredFileChange`, `StructuredHunk`, `StructuredLine` — diff tool JSON output (shared by PR and local tools); `PrNumber` is `int?` (null for local diffs, omitted from JSON); +`Pagination` (PaginationMetadataResult?) and `StalenessWarning` (StalenessWarningResult?) nullable properties (Feature 004) |
-| `REBUSS.Pure\Tools\Models\PullRequestMetadataResult.cs` | `PullRequestMetadataResult`, `AuthorInfo`, `RefInfo`, `PrStats`, `DescriptionInfo`, `SourceInfo` |
+| `REBUSS.Pure\Tools\Models\PullRequestMetadataResult.cs` | `PullRequestMetadataResult`, `AuthorInfo`, `RefInfo`, `PrStats`, `DescriptionInfo`, `SourceInfo`; +`ContentPaging` (ContentPagingInfo?) nullable property for pagination info when budget params provided |
+| `REBUSS.Pure\Tools\Models\ContentPagingInfo.cs` | `ContentPagingInfo` (totalPages, totalFiles, budgetPerPageTokens, filesByPage), `PageFileCount` (pageNumber, fileCount) — pagination overview included in `get_pr_metadata` response |
+| `REBUSS.Pure\Tools\Models\PullRequestContentPageResult.cs` | `PullRequestContentPageResult` (prNumber, pageNumber, totalPages, files, summary), `ContentPageSummary` (filesOnPage, totalFiles, estimatedTokens, hasMorePages, categories) — response DTO for `get_pr_content`; `ContentPageSummary` shared with `LocalContentPageResult` |
+| `REBUSS.Pure\Tools\Models\LocalContentPageResult.cs` | `LocalContentPageResult` (repositoryRoot, currentBranch?, scope, pageNumber, totalPages, files, summary) — response DTO for `get_local_content`; reuses `ContentPageSummary` |
 | `REBUSS.Pure\Tools\Models\PullRequestFilesResult.cs` | `PullRequestFilesResult`, `PullRequestFileItem`, `PullRequestFilesSummaryResult` (also reused by `LocalReviewFilesResult`); +`Pagination` (PaginationMetadataResult?) and `StalenessWarning` (StalenessWarningResult?) nullable properties (Feature 004) |
 | `REBUSS.Pure\Tools\Models\FileContentAtRefResult.cs` | `FileContentAtRefResult` |
 | `REBUSS.Pure\Tools\Models\LocalReviewFilesResult.cs` | `LocalReviewFilesResult` — JSON output for `get_local_files`; includes `repositoryRoot`, `scope`, `currentBranch` context fields; +`Pagination` (PaginationMetadataResult?) nullable property (Feature 004, no staleness for local tools) |
@@ -309,8 +314,8 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | `REBUSS.Pure\Cli\AzureDevOpsCliAuthFlow.cs` | Azure DevOps auth flow: checks for Azure CLI, runs `az login`, caches token; offers to install Azure CLI if not found |
 | `REBUSS.Pure\Cli\GitHubCliAuthFlow.cs` | GitHub auth flow: checks for GitHub CLI, runs `gh auth login --web`, caches token; offers to install GitHub CLI if not found |
 | `REBUSS.Pure\Cli\InitCommand.cs` | `init` command: generates MCP config files (local or global via `-g`), supports `--ide vscode`/`--ide vs` to force a specific IDE target (skips auto-detection), copies prompt and instruction files (always overwrites `.github/prompts/*.md` and `.github/instructions/*.instructions.md` to enable updates), delegates authentication to `ICliAuthFlow` via `CreateAuthFlow()` (selects `GitHubCliAuthFlow` or `AzureDevOpsCliAuthFlow` based on `DetectProviderFromGitRemote()` or explicit `--provider`); global mode writes to `~/.vs/mcp.json` and `~/.vscode/mcp.json` via `ResolveGlobalConfigTargets()` |
-| `REBUSS.Pure\Cli\Prompts\review-pr.md` | Embedded resource: PR review prompt template |
-| `REBUSS.Pure\Cli\Prompts\self-review.md` | Embedded resource: self-review prompt template |
+| `REBUSS.Pure\Cli\Prompts\review-pr.md` | Embedded resource: PR review prompt template; redesigned for `get_pr_metadata`(with budget) + `get_pr_content` page loop workflow; legacy tools documented as available |
+| `REBUSS.Pure\Cli\Prompts\self-review.md` | Embedded resource: self-review prompt template; redesigned for `get_local_content` page loop workflow; legacy tools documented as available |
 | `REBUSS.Pure\Cli\Prompts\create-pr.md` | Embedded resource: create-PR prompt template (not yet deployed by `init`; reserved for future `#create-pr` command) |
 
 ### Logging
@@ -384,10 +389,13 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | `REBUSS.Pure.Tests\Tools\GetFileContentAtRefToolHandlerTests.cs` | `GetFileContentAtRefToolHandler` — structured JSON output, validation (McpException), provider exceptions (McpException) |
 | `REBUSS.Pure.Tests\Tools\GetLocalChangesFilesToolHandlerTests.cs` | `GetLocalChangesFilesToolHandler` — scope parsing, JSON output, error handling (McpException), packing manifest |
 | `REBUSS.Pure.Tests\Tools\GetLocalFileDiffToolHandlerTests.cs` | `GetLocalFileDiffToolHandler` — structured JSON output, validation (McpException), scope routing, error handling (McpException), packing manifest |
+| `REBUSS.Pure.Tests\Tools\GetPullRequestMetadataToolHandlerTests.cs` | `GetPullRequestMetadataToolHandler` — structured JSON output, validation (McpException), provider exceptions, +contentPaging computation (stat-based estimation, page allocation, backward compatibility without budget params) |
+| `REBUSS.Pure.Tests\Tools\GetPullRequestContentToolHandlerTests.cs` | `GetPullRequestContentToolHandler` — structured JSON output, validation (McpException), pagination (page filtering, category breakdown, multi-page, out-of-range), PR not found error |
+| `REBUSS.Pure.Tests\Tools\GetLocalContentToolHandlerTests.cs` | `GetLocalContentToolHandler` — structured JSON output, validation (McpException), pagination (per-file diff fetch, category breakdown, scope routing, multi-page, out-of-range) |
 | `REBUSS.Pure.Tests\Services\LocalReview\LocalReviewScopeTests.cs` | `LocalReviewScope.Parse` — all scope kinds, ToString |
 | `REBUSS.Pure.Tests\Services\LocalReview\LocalGitClientParseTests.cs` | `LocalGitClient` porcelain/name-status parsing — via reflection on internal static methods |
 | `REBUSS.Pure.Tests\Services\LocalReview\LocalReviewProviderTests.cs` | `LocalReviewProvider` — files listing, status mapping, classification, file diff, skip reasons, exception cases |
-| `REBUSS.Pure.Tests\Services\ContextWindow\TokenEstimatorTests.cs` | `TokenEstimator` — token estimation accuracy, null/empty input, boundary conditions, custom ratio, invalid ratio fallback, rounding |
+| `REBUSS.Pure.Tests\Services\ContextWindow\TokenEstimatorTests.cs` | `TokenEstimator` — token estimation accuracy, null/empty input, boundary conditions, custom ratio, invalid ratio fallback, rounding; +`EstimateFromStats` tests (additions+deletions, zero lines fallback, negative values clamped) |
 | `REBUSS.Pure.Tests\Services\ContextWindow\ContextBudgetResolverTests.cs` | `ContextBudgetResolver` — explicit budget, registry lookup, default fallback, guardrails, safety margin, case-insensitive matching, edge cases |
 | `REBUSS.Pure.Tests\Services\PackingPriorityComparerTests.cs` | `PackingPriorityComparer` — FileCategory ordering, TotalChanges secondary sort, Path tiebreaker, null handling |
 | `REBUSS.Pure.Tests\Services\ResponsePackerTests.cs` | `ResponsePacker` — empty candidates, all-fit, budget exceeded, partial assignment, priority ordering, manifest correctness, utilization |
@@ -417,7 +425,7 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | `REBUSS.Pure.SmokeTests\Expectations\AdoTestExpectations.cs` | Expected values from Azure DevOps fixture PR (title, state, file paths, statuses, code fragments) |
 | `REBUSS.Pure.SmokeTests\Expectations\GitHubTestExpectations.cs` | Expected values from GitHub fixture PR (title, state, file paths, statuses, code fragments) |
 | `REBUSS.Pure.SmokeTests\Protocol\InitializeProtocolTests.cs` | Protocol tests (no credentials): MCP initialize handshake — protocol version, server info, capabilities |
-| `REBUSS.Pure.SmokeTests\Protocol\ToolsListProtocolTests.cs` | Protocol tests (no credentials): tools/list — tool count, names, schemas; PrNumberTools checks property declaration (not required array) for get_file_diff+get_pr_metadata, +PaginationEnabledTools array, +2 schema assertions for F004 pagination parameters |
+| `REBUSS.Pure.SmokeTests\Protocol\ToolsListProtocolTests.cs` | Protocol tests (no credentials): tools/list — tool count (9), names, schemas; PrNumberTools checks property declaration (not required array) for get_file_diff+get_pr_metadata+get_pr_content, +PaginationEnabledTools array, +2 schema assertions for F004 pagination parameters, +ContentTools_HavePageNumberProperty for get_pr_content/get_local_content |
 | `REBUSS.Pure.SmokeTests\Contracts\AzureDevOps\AdoMetadataContractTests.cs` | Contract tests (ADO): `get_pr_metadata` — PR number, title, state, branches, author, stats, commits, source, description, isDraft |
 | `REBUSS.Pure.SmokeTests\Contracts\AzureDevOps\AdoFilesContractTests.cs` | Contract tests (ADO): `get_pr_files` — file count, paths, statuses, additions/deletions, extension, classification, review priority, binary/generated |
 | `REBUSS.Pure.SmokeTests\Contracts\AzureDevOps\AdoDiffContractTests.cs` | Contract tests (ADO): `get_pr_diff` — PR number, file count, hunks, structure, line ops, additions/deletions, code fragment |
@@ -501,6 +509,7 @@ IScmClient / IPullRequestDataProvider / IFileContentDataProvider [Core interface
   ? GetPullRequestDiffToolHandler [Pure]           (consumes IPullRequestDataProvider)
   ? GetFileDiffToolHandler [Pure]                  (consumes IPullRequestDataProvider)
   ? GetPullRequestMetadataToolHandler [Pure]       (consumes IPullRequestDataProvider)
+  ? GetPullRequestContentToolHandler [Pure]        (consumes IPullRequestDataProvider)
   ? GetPullRequestFilesToolHandler [Pure]          (consumes IPullRequestDataProvider)
   ? GetFileContentAtRefToolHandler [Pure]          (consumes IFileContentDataProvider)
   ? AnalysisInput [Core]                           (carries IFileContentDataProvider for on-demand content fetching)
@@ -519,10 +528,12 @@ LocalReviewScope / LocalFileStatus
   ? LocalReviewProvider [Pure]                     (consumes: orchestrates git client + diff builder)
   ? GetLocalChangesFilesToolHandler [Pure]          (consumes scope string ? parse ? pass to provider)
   ? GetLocalFileDiffToolHandler [Pure]              (consumes scope string + path ? pass to provider)
+  ? GetLocalContentToolHandler [Pure]               (consumes scope string + pageNumber ? pass to provider)
 
 LocalReviewFiles
   ? LocalReviewProvider [Pure]                     (produces)
   ? GetLocalChangesFilesToolHandler [Pure]          (consumes: maps to LocalReviewFilesResult)
+  ? GetLocalContentToolHandler [Pure]               (consumes: maps to LocalContentPageResult)
 
 AzureDevOpsOptions (+ LocalRepoPath) [AzureDevOps]
   ? ConfigurationResolver [AzureDevOps]            (IPostConfigureOptions: merges user > detected > cached values into options)

--- a/.github/Contracts.md
+++ b/.github/Contracts.md
@@ -65,6 +65,8 @@ Error messages by tool:
 - `get_file_content_at_ref`: `"File not found: ..."`, `"Error retrieving file content: ..."`
 - `get_local_files`: `"Repository not found: ..."`, `"Git command failed: ..."`
 - `get_local_file_diff`: `"File not found in local changes: ..."`, `"Repository not found: ..."`, `"Git command failed: ..."`
+- `get_pr_content`: `"Missing required parameter: prNumber"`, `"Missing required parameter: pageNumber"`, `"pageNumber N exceeds total pages M"`, `"Pull Request not found: ..."`, `"Error retrieving PR content: ..."`
+- `get_local_content`: `"Missing required parameter: pageNumber"`, `"pageNumber N exceeds total pages M"`, `"Error retrieving local content: ..."`
 
 ### JSON-RPC errors (protocol level)
 
@@ -150,11 +152,15 @@ Auto-generated JSON Schema:
 
 #### Input
 
-Auto-generated from `GetPullRequestMetadataToolHandler.ExecuteAsync` signature.
+Auto-generated from `GetPullRequestMetadataToolHandler.ExecuteAsync` signature. `prNumber` is logically required (validated at runtime); budget parameters are optional and trigger `contentPaging` computation.
 
-| Parameter | C# Type | Required | Description |
-|---|---|---|---|
-| `prNumber` | `int` | ✅ | The Pull Request number/ID to retrieve metadata for |
+| Parameter | C# Type | Required | Default | Description |
+|---|---|---|---|---|
+| `prNumber` | `int?` | ✅ (runtime) | `null` | The Pull Request number/ID to retrieve metadata for |
+| `modelName` | `string?` | ❌ | `null` | Model name for context budget resolution (e.g. `"gpt-4o"`). Triggers pagination info. |
+| `maxTokens` | `int?` | ❌ | `null` | Explicit token budget override. Triggers pagination info. |
+
+> **Feature 005 note:** When `modelName` or `maxTokens` is provided, the response includes a `contentPaging` section with page allocation info for use with `get_pr_content`.
 
 #### Output — `PullRequestMetadataResult`
 
@@ -173,7 +179,19 @@ Auto-generated from `GetPullRequestMetadataToolHandler.ExecuteAsync` signature.
   "stats": { "commits": 3, "changedFiles": 5, "additions": 120, "deletions": 40 },
   "commitShas": ["def456", "789abc", "012def"],
   "description": { "text": "PR description...", "isTruncated": false, "originalLength": 18, "returnedLength": 18 },
-  "source": { "repository": "org/repo", "url": "https://dev.azure.com/org/project/_git/repo/pullrequest/42" }
+  "source": { "repository": "org/repo", "url": "https://dev.azure.com/org/project/_git/repo/pullrequest/42" },
+  "contentPaging": {
+    "totalPages": 5,
+    "totalFiles": 286,
+    "budgetPerPageTokens": 89600,
+    "filesByPage": [
+      { "pageNumber": 1, "fileCount": 12 },
+      { "pageNumber": 2, "fileCount": 15 },
+      { "pageNumber": 3, "fileCount": 18 },
+      { "pageNumber": 4, "fileCount": 14 },
+      { "pageNumber": 5, "fileCount": 8 }
+    ]
+  }
 }
 ```
 
@@ -185,6 +203,11 @@ Auto-generated from `GetPullRequestMetadataToolHandler.ExecuteAsync` signature.
 | `updatedAt` | string | **yes** | Set to `closedDate` if present; omitted when null |
 | `description.text` | string | no | Truncated to **800 chars** if longer |
 | `description.isTruncated` | bool | no | `true` when original exceeded 800 chars |
+| `contentPaging` | object | **yes** | Only present when `modelName` or `maxTokens` is provided; omitted otherwise (WhenWritingNull) |
+| `contentPaging.totalPages` | int | no | Total number of content pages |
+| `contentPaging.totalFiles` | int | no | Total number of changed files across all pages |
+| `contentPaging.budgetPerPageTokens` | int | no | Safe token budget used for page allocation |
+| `contentPaging.filesByPage` | array | no | Per-page file count breakdown (`PageFileCount[]`) |
 
 ---
 
@@ -491,12 +514,138 @@ Same `StructuredDiffResult` shape with `manifest`. `prNumber` is `null` (omitted
 
 ---
 
+### 4.8 `get_pr_content`
+
+#### Input
+
+Auto-generated from `GetPullRequestContentToolHandler.ExecuteAsync` signature. All parameters are nullable with defaults, making them optional in the schema. `prNumber` and `pageNumber` are logically required (validated at runtime).
+
+| Parameter | C# Type | Required | Default | Description |
+|---|---|---|---|---|
+| `prNumber` | `int?` | ✅ (runtime) | `null` | The Pull Request number/ID |
+| `pageNumber` | `int?` | ✅ (runtime) | `null` | Page number to retrieve (1-based) |
+| `modelName` | `string?` | ❌ | `null` | Model name for context budget resolution |
+| `maxTokens` | `int?` | ❌ | `null` | Explicit token budget override |
+
+#### Output — `PullRequestContentPageResult`
+
+```json
+{
+  "prNumber": 42,
+  "pageNumber": 1,
+  "totalPages": 5,
+  "files": [
+    {
+      "path": "src/Cache/CacheService.cs",
+      "changeType": "edit",
+      "additions": 5, "deletions": 2,
+      "hunks": [
+        {
+          "oldStart": 10, "oldCount": 7, "newStart": 10, "newCount": 10,
+          "lines": [
+            { "op": " ", "text": "    public class CacheService" },
+            { "op": "-", "text": "        private int _ttl = 60;" },
+            { "op": "+", "text": "        private int _ttl = 300;" }
+          ]
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "filesOnPage": 12,
+    "totalFiles": 286,
+    "estimatedTokens": 85000,
+    "hasMorePages": true,
+    "categories": { "source": 8, "test": 3, "config": 1 }
+  }
+}
+```
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `prNumber` | int | no | Echoes input PR number |
+| `pageNumber` | int | no | Current page (1-based) |
+| `totalPages` | int | no | Total number of pages |
+| `files` | array | no | `StructuredFileChange[]` — diff content for files on this page |
+| `summary.filesOnPage` | int | no | Number of files included on this page |
+| `summary.totalFiles` | int | no | Total files across all pages |
+| `summary.estimatedTokens` | int | no | Estimated token usage for this page |
+| `summary.hasMorePages` | bool | no | `true` when `pageNumber < totalPages` |
+| `summary.categories` | object | no | File count by category (e.g. `"source"`, `"test"`, `"config"`) |
+
+Error messages: `"Missing required parameter: prNumber"`, `"prNumber must be greater than 0"`, `"Missing required parameter: pageNumber"`, `"pageNumber must be >= 1"`, `"pageNumber N exceeds total pages M"`, `"Pull Request not found: ..."`, `"Error retrieving PR content: ..."`.
+
+---
+
+### 4.9 `get_local_content`
+
+#### Input
+
+Auto-generated from `GetLocalContentToolHandler.ExecuteAsync` signature. All parameters are nullable with defaults, making them optional in the schema. `pageNumber` is logically required (validated at runtime).
+
+| Parameter | C# Type | Required | Default | Description |
+|---|---|---|---|---|
+| `pageNumber` | `int?` | ✅ (runtime) | `null` | Page number to retrieve (1-based) |
+| `scope` | `string?` | ❌ | `null` (resolved to `"working-tree"`) | Review scope: `"working-tree"`, `"staged"`, or a branch/ref name |
+| `modelName` | `string?` | ❌ | `null` | Model name for context budget resolution |
+| `maxTokens` | `int?` | ❌ | `null` | Explicit token budget override |
+
+#### Output — `LocalContentPageResult`
+
+```json
+{
+  "repositoryRoot": "C:/Projects/MyApp",
+  "currentBranch": "feature/cache",
+  "scope": "working-tree",
+  "pageNumber": 1,
+  "totalPages": 2,
+  "files": [
+    {
+      "path": "src/Cache/CacheService.cs",
+      "changeType": "edit",
+      "additions": 5, "deletions": 2,
+      "hunks": [
+        {
+          "oldStart": 10, "oldCount": 7, "newStart": 10, "newCount": 10,
+          "lines": [
+            { "op": " ", "text": "    public class CacheService" },
+            { "op": "-", "text": "        private int _ttl = 60;" },
+            { "op": "+", "text": "        private int _ttl = 300;" }
+          ]
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "filesOnPage": 5,
+    "totalFiles": 8,
+    "estimatedTokens": 12000,
+    "hasMorePages": true,
+    "categories": { "source": 3, "test": 1, "config": 1 }
+  }
+}
+```
+
+| Field | Type | Nullable | Notes |
+|---|---|---|---|
+| `repositoryRoot` | string | no | Absolute path to the repository root |
+| `currentBranch` | string | **yes** | Omitted when detached HEAD |
+| `scope` | string | no | Echoes the resolved scope value |
+| `pageNumber` | int | no | Current page (1-based) |
+| `totalPages` | int | no | Total number of pages |
+| `files` | array | no | `StructuredFileChange[]` — diff content for files on this page |
+| `summary` | object | no | `ContentPageSummary` — same shape as `get_pr_content` summary |
+
+Error messages: `"Missing required parameter: pageNumber"`, `"pageNumber must be >= 1"`, `"pageNumber N exceeds total pages M"`, `"Error retrieving local content: ..."`.
+
+---
+
 ## 5. Shared DTO Reference
 
 | DTO | Used by | Fields |
 |---|---|---|
 | **StructuredDiffResult** | `get_pr_diff`, `get_file_diff`, `get_local_file_diff` | `prNumber` (int?), `files` (StructuredFileChange[]), `manifest`? (ContentManifestResult), `pagination`? (PaginationMetadataResult — Feature 004), `stalenessWarning`? (StalenessWarningResult — Feature 004) |
-| **StructuredFileChange** | nested in above | `path`, `changeType`, `skipReason`?, `additions`, `deletions`, `hunks` |
+| **StructuredFileChange** | nested in StructuredDiffResult, `get_pr_content`, `get_local_content` | `path`, `changeType`, `skipReason`?, `additions`, `deletions`, `hunks` |
 | **StructuredHunk** | nested in above | `oldStart`, `oldCount`, `newStart`, `newCount`, `lines` |
 | **StructuredLine** | nested in above | `op`, `text` |
 | **PullRequestFileItem** | `get_pr_files`, `get_local_files` | `path`, `status`, `additions`, `deletions`, `changes`, `extension`, `isBinary`, `isGenerated`, `isTestFile`, `reviewPriority` |
@@ -504,6 +653,12 @@ Same `StructuredDiffResult` shape with `manifest`. `prNumber` is `null` (omitted
 | **ContentManifestResult** | `get_pr_diff`, `get_pr_files`, `get_local_files`, `get_local_file_diff` | `items` (ManifestEntryResult[]), `summary` (ManifestSummaryResult) |
 | **ManifestEntryResult** | nested in ContentManifestResult | `path`, `estimatedTokens`, `status`, `priorityTier` |
 | **ManifestSummaryResult** | nested in ContentManifestResult | `totalItems`, `includedCount`, `partialCount`, `deferredCount`, `totalBudgetTokens`, `budgetUsed`, `budgetRemaining`, `utilizationPercent`, `includedOnThisPage`? (int? — Feature 004), `remainingAfterThisPage`? (int? — Feature 004), `totalPages`? (int? — Feature 004) |
+| **PullRequestMetadataResult** | `get_pr_metadata` | `prNumber`, `id`, `title`, `author` (AuthorInfo), `state`, `isDraft`, `createdAt`, `updatedAt`?, `base` (RefInfo), `head` (RefInfo), `stats` (PrStats), `commitShas`, `description` (DescriptionInfo), `source` (SourceInfo), `contentPaging`? (ContentPagingInfo) |
+| **ContentPagingInfo** | `get_pr_metadata` (when budget params provided) | `totalPages` (int), `totalFiles` (int), `budgetPerPageTokens` (int), `filesByPage` (PageFileCount[]) |
+| **PageFileCount** | nested in ContentPagingInfo | `pageNumber` (int), `fileCount` (int) |
+| **PullRequestContentPageResult** | `get_pr_content` | `prNumber` (int), `pageNumber` (int), `totalPages` (int), `files` (StructuredFileChange[]), `summary` (ContentPageSummary) |
+| **LocalContentPageResult** | `get_local_content` | `repositoryRoot` (string), `currentBranch`? (string), `scope` (string), `pageNumber` (int), `totalPages` (int), `files` (StructuredFileChange[]), `summary` (ContentPageSummary) |
+| **ContentPageSummary** | `get_pr_content`, `get_local_content` | `filesOnPage` (int), `totalFiles` (int), `estimatedTokens` (int), `hasMorePages` (bool), `categories` (Dictionary<string, int>) |
 | **AuthorInfo** | `get_pr_metadata` | `login`, `displayName` |
 | **RefInfo** | `get_pr_metadata` | `ref`, `sha` |
 | **PrStats** | `get_pr_metadata` | `commits`, `changedFiles`, `additions`, `deletions` |

--- a/REBUSS.Pure.Core/ITokenEstimator.cs
+++ b/REBUSS.Pure.Core/ITokenEstimator.cs
@@ -17,4 +17,14 @@ public interface ITokenEstimator
     /// <param name="safeBudgetTokens">The available safe budget in tokens.</param>
     /// <returns>Estimation result with token count, percentage, and fit signal.</returns>
     TokenEstimationResult Estimate(string serializedContent, int safeBudgetTokens);
+
+    /// <summary>
+    /// Estimates the token count for a file diff based on line-change statistics,
+    /// without requiring the actual diff content. Uses a fixed per-line token factor
+    /// plus a per-file overhead constant.
+    /// </summary>
+    /// <param name="additions">Number of added lines (clamped to 0 if negative).</param>
+    /// <param name="deletions">Number of deleted lines (clamped to 0 if negative).</param>
+    /// <returns>Estimated token count (always ≥ PerFileOverhead).</returns>
+    int EstimateFromStats(int additions, int deletions);
 }

--- a/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
+++ b/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
@@ -18,13 +18,16 @@ public class ToolsListProtocolTests
         "get_pr_files",
         "get_file_content_at_ref",
         "get_local_files",
-        "get_local_file_diff"
+        "get_local_file_diff",
+        "get_pr_content",
+        "get_local_content"
     ];
 
     private static readonly string[] PrNumberTools =
     [
         "get_file_diff",
-        "get_pr_metadata"
+        "get_pr_metadata",
+        "get_pr_content"
     ];
 
     /// <summary>
@@ -45,14 +48,14 @@ public class ToolsListProtocolTests
     }
 
     [Fact]
-    public async Task ToolsList_ReturnsAllSevenTools()
+    public async Task ToolsList_ReturnsAllNineTools()
     {
         var response = await _fixture.Server.SendToolsListAsync();
         var tools = response.RootElement
             .GetProperty("result")
             .GetProperty("tools");
 
-        Assert.Equal(7, tools.GetArrayLength());
+        Assert.Equal(9, tools.GetArrayLength());
     }
 
     [Fact]
@@ -171,5 +174,34 @@ public class ToolsListProtocolTests
             "get_local_file_diff should not have pageReference (excluded from pagination).");
         Assert.False(props.TryGetProperty("pageNumber", out _),
             "get_local_file_diff should not have pageNumber (excluded from pagination).");
+    }
+
+    /// <summary>
+    /// Feature 003: New content tools must declare pageNumber property.
+    /// </summary>
+    [Fact]
+    public async Task ToolsList_ContentTools_HavePageNumberProperty()
+    {
+        var response = await _fixture.Server.SendToolsListAsync();
+        var tools = response.RootElement
+            .GetProperty("result")
+            .GetProperty("tools");
+
+        var toolMap = tools.EnumerateArray()
+            .ToDictionary(
+                t => t.GetProperty("name").GetString()!,
+                t => t);
+
+        foreach (var toolName in new[] { "get_pr_content", "get_local_content" })
+        {
+            Assert.True(toolMap.ContainsKey(toolName), $"Tool '{toolName}' not found.");
+
+            var schema = toolMap[toolName].GetProperty("inputSchema");
+            Assert.True(schema.TryGetProperty("properties", out var props),
+                $"Tool '{toolName}' has no 'properties' in schema.");
+
+            Assert.True(props.TryGetProperty("pageNumber", out _),
+                $"Tool '{toolName}' is missing 'pageNumber' property.");
+        }
     }
 }

--- a/REBUSS.Pure.Tests/Services/ContextWindow/TokenEstimatorTests.cs
+++ b/REBUSS.Pure.Tests/Services/ContextWindow/TokenEstimatorTests.cs
@@ -138,4 +138,59 @@ public class TokenEstimatorTests
         Assert.Equal(100.0, result.PercentageUsed);
         Assert.False(result.FitsWithinBudget);
     }
+
+    // --- EstimateFromStats tests --------------------------------------------------
+
+    [Fact]
+    public void EstimateFromStats_TypicalValues_ReturnsLineTimesFactorPlusOverhead()
+    {
+        var estimator = CreateEstimator();
+
+        // (10 + 5) * 15 + 50 = 275
+        var result = estimator.EstimateFromStats(additions: 10, deletions: 5);
+
+        Assert.Equal(275, result);
+    }
+
+    [Fact]
+    public void EstimateFromStats_ZeroLines_ReturnsOverheadOnly()
+    {
+        var estimator = CreateEstimator();
+
+        var result = estimator.EstimateFromStats(additions: 0, deletions: 0);
+
+        Assert.Equal(50, result);
+    }
+
+    [Fact]
+    public void EstimateFromStats_NegativeValues_ClampedToZero()
+    {
+        var estimator = CreateEstimator();
+
+        var result = estimator.EstimateFromStats(additions: -5, deletions: -10);
+
+        Assert.Equal(50, result);
+    }
+
+    [Fact]
+    public void EstimateFromStats_OneNegativeOnePositive_ClampsNegativeOnly()
+    {
+        var estimator = CreateEstimator();
+
+        // Max(0, -3) + Max(0, 20) = 20 lines → 20 * 15 + 50 = 350
+        var result = estimator.EstimateFromStats(additions: -3, deletions: 20);
+
+        Assert.Equal(350, result);
+    }
+
+    [Fact]
+    public void EstimateFromStats_LargeValues_ScalesLinearly()
+    {
+        var estimator = CreateEstimator();
+
+        // (1000 + 500) * 15 + 50 = 22_550
+        var result = estimator.EstimateFromStats(additions: 1000, deletions: 500);
+
+        Assert.Equal(22_550, result);
+    }
 }

--- a/REBUSS.Pure.Tests/Tools/GetLocalContentToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetLocalContentToolHandlerTests.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.Pagination;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Services.LocalReview;
+using REBUSS.Pure.Tools;
+
+namespace REBUSS.Pure.Tests.Tools;
+
+public class GetLocalContentToolHandlerTests
+{
+    private readonly ILocalReviewProvider _localProvider = Substitute.For<ILocalReviewProvider>();
+    private readonly IContextBudgetResolver _budgetResolver = Substitute.For<IContextBudgetResolver>();
+    private readonly ITokenEstimator _tokenEstimator = Substitute.For<ITokenEstimator>();
+    private readonly IFileClassifier _fileClassifier = Substitute.For<IFileClassifier>();
+    private readonly IPageAllocator _pageAllocator = Substitute.For<IPageAllocator>();
+    private readonly GetLocalContentToolHandler _handler;
+
+    private static readonly LocalReviewFiles SampleLocalFiles = new()
+    {
+        RepositoryRoot = "C:\\Projects\\MyRepo",
+        CurrentBranch = "feature/my-branch",
+        Scope = "working-tree",
+        Files = new List<PullRequestFileInfo>
+        {
+            new() { Path = "src/A.cs", Additions = 20, Deletions = 3, Changes = 23, Extension = ".cs" },
+            new() { Path = "src/B.cs", Additions = 10, Deletions = 2, Changes = 12, Extension = ".cs" }
+        }
+    };
+
+    private static PullRequestDiff MakeFileDiff(string path, int additions, int deletions)
+    {
+        return new PullRequestDiff
+        {
+            Files = new List<FileChange>
+            {
+                new()
+                {
+                    Path = path,
+                    ChangeType = "edit",
+                    Additions = additions,
+                    Deletions = deletions,
+                    Hunks = new List<DiffHunk>
+                    {
+                        new()
+                        {
+                            OldStart = 1, OldCount = deletions, NewStart = 1, NewCount = additions,
+                            Lines = new List<DiffLine> { new() { Op = '+', Text = "new" } }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    public GetLocalContentToolHandlerTests()
+    {
+        _localProvider.GetFilesAsync(Arg.Any<LocalReviewScope>(), Arg.Any<CancellationToken>())
+            .Returns(SampleLocalFiles);
+        _localProvider.GetFileDiffAsync("src/A.cs", Arg.Any<LocalReviewScope>(), Arg.Any<CancellationToken>())
+            .Returns(MakeFileDiff("src/A.cs", 20, 3));
+        _localProvider.GetFileDiffAsync("src/B.cs", Arg.Any<LocalReviewScope>(), Arg.Any<CancellationToken>())
+            .Returns(MakeFileDiff("src/B.cs", 10, 2));
+
+        _budgetResolver.Resolve(Arg.Any<int?>(), Arg.Any<string?>())
+            .Returns(new BudgetResolutionResult(200000, 140000, BudgetSource.Default, Array.Empty<string>()));
+        _tokenEstimator.EstimateFromStats(Arg.Any<int>(), Arg.Any<int>())
+            .Returns(500);
+        _fileClassifier.Classify(Arg.Any<string>())
+            .Returns(new FileClassification { Category = FileCategory.Source });
+
+        var pageSlice = new PageSlice(1, 0, 2,
+            new[]
+            {
+                new PageSliceItem(0, PackingItemStatus.Included, 500),
+                new PageSliceItem(1, PackingItemStatus.Included, 500)
+            },
+            1000, 139000);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { pageSlice }, 1, 2));
+
+        _handler = new GetLocalContentToolHandler(
+            _localProvider,
+            _budgetResolver,
+            _tokenEstimator,
+            _fileClassifier,
+            _pageAllocator,
+            NullLogger<GetLocalContentToolHandler>.Instance);
+    }
+
+    // --- Happy path ---
+
+    [Fact]
+    public async Task ExecuteAsync_SinglePage_ReturnsAllFiles()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(1, doc.RootElement.GetProperty("pageNumber").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("totalPages").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("files").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IncludesRepositoryRoot()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal("C:\\Projects\\MyRepo", doc.RootElement.GetProperty("repositoryRoot").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IncludesCurrentBranch()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal("feature/my-branch", doc.RootElement.GetProperty("currentBranch").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultScope_IsWorkingTree()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal("working-tree", doc.RootElement.GetProperty("scope").GetString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_StagedScope_Forwarded()
+    {
+        await _handler.ExecuteAsync(pageNumber: 1, scope: "staged");
+
+        await _localProvider.Received(1).GetFilesAsync(
+            Arg.Is<LocalReviewScope>(s => s.Kind == LocalReviewScopeKind.Staged),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BranchScope_ForwardedAsBaseBranch()
+    {
+        await _handler.ExecuteAsync(pageNumber: 1, scope: "main");
+
+        await _localProvider.Received(1).GetFilesAsync(
+            Arg.Is<LocalReviewScope>(s => s.Kind == LocalReviewScopeKind.BranchDiff && s.BaseBranch == "main"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Summary_HasCorrectValues()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        var summary = doc.RootElement.GetProperty("summary");
+        Assert.Equal(2, summary.GetProperty("filesOnPage").GetInt32());
+        Assert.Equal(2, summary.GetProperty("totalFiles").GetInt32());
+        Assert.Equal(1000, summary.GetProperty("estimatedTokens").GetInt32());
+        Assert.False(summary.GetProperty("hasMorePages").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Summary_HasCategories()
+    {
+        var json = await _handler.ExecuteAsync(pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        var categories = doc.RootElement.GetProperty("summary").GetProperty("categories");
+        Assert.Equal(2, categories.GetProperty("source").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OnlyFetchesDiffsForPageFiles()
+    {
+        var slice1 = new PageSlice(1, 0, 1,
+            new[] { new PageSliceItem(0, PackingItemStatus.Included, 500) },
+            500, 139500);
+        var slice2 = new PageSlice(2, 1, 2,
+            new[] { new PageSliceItem(1, PackingItemStatus.Included, 500) },
+            500, 139500);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { slice1, slice2 }, 2, 2));
+
+        await _handler.ExecuteAsync(pageNumber: 1);
+
+        // Only first file's diff should be fetched
+        await _localProvider.Received(1).GetFileDiffAsync(
+            "src/A.cs", Arg.Any<LocalReviewScope>(), Arg.Any<CancellationToken>());
+        await _localProvider.DidNotReceive().GetFileDiffAsync(
+            "src/B.cs", Arg.Any<LocalReviewScope>(), Arg.Any<CancellationToken>());
+    }
+
+    // --- Error handling ---
+
+    [Fact]
+    public async Task ExecuteAsync_NullPageNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(pageNumber: null));
+        Assert.Contains("pageNumber", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ZeroPageNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(pageNumber: 0));
+        Assert.Contains("pageNumber must be >= 1", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PageExceedsTotalPages_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(pageNumber: 99));
+        Assert.Contains("exceeds total pages", ex.Message);
+    }
+
+    // --- Budget forwarding ---
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsBudgetParams()
+    {
+        await _handler.ExecuteAsync(pageNumber: 1, modelName: "gpt-4o", maxTokens: 50000);
+
+        _budgetResolver.Received(1).Resolve(50000, "gpt-4o");
+    }
+}

--- a/REBUSS.Pure.Tests/Tools/GetPullRequestContentToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetPullRequestContentToolHandlerTests.cs
@@ -1,0 +1,268 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Exceptions;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.Pagination;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Tools;
+
+namespace REBUSS.Pure.Tests.Tools;
+
+public class GetPullRequestContentToolHandlerTests
+{
+    private readonly IPullRequestDataProvider _dataProvider = Substitute.For<IPullRequestDataProvider>();
+    private readonly IContextBudgetResolver _budgetResolver = Substitute.For<IContextBudgetResolver>();
+    private readonly ITokenEstimator _tokenEstimator = Substitute.For<ITokenEstimator>();
+    private readonly IFileClassifier _fileClassifier = Substitute.For<IFileClassifier>();
+    private readonly IPageAllocator _pageAllocator = Substitute.For<IPageAllocator>();
+    private readonly GetPullRequestContentToolHandler _handler;
+
+    private static readonly PullRequestFiles SampleFiles = new()
+    {
+        Files = new List<PullRequestFileInfo>
+        {
+            new() { Path = "src/A.cs", Additions = 30, Deletions = 5, Changes = 35, Extension = ".cs" },
+            new() { Path = "src/B.cs", Additions = 20, Deletions = 5, Changes = 25, Extension = ".cs" },
+            new() { Path = "docs/README.md", Additions = 3, Deletions = 1, Changes = 4, Extension = ".md" }
+        }
+    };
+
+    private static readonly PullRequestDiff SampleDiff = new()
+    {
+        Title = "Fix bug",
+        Status = "active",
+        SourceBranch = "feature/x",
+        TargetBranch = "main",
+        Files = new List<FileChange>
+        {
+            new()
+            {
+                Path = "src/A.cs", ChangeType = "edit", Additions = 30, Deletions = 5,
+                Hunks = new List<DiffHunk>
+                {
+                    new()
+                    {
+                        OldStart = 1, OldCount = 5, NewStart = 1, NewCount = 10,
+                        Lines = new List<DiffLine> { new() { Op = '+', Text = "new line" } }
+                    }
+                }
+            },
+            new()
+            {
+                Path = "src/B.cs", ChangeType = "edit", Additions = 20, Deletions = 5,
+                Hunks = new List<DiffHunk>
+                {
+                    new()
+                    {
+                        OldStart = 1, OldCount = 5, NewStart = 1, NewCount = 10,
+                        Lines = new List<DiffLine> { new() { Op = '+', Text = "another line" } }
+                    }
+                }
+            },
+            new()
+            {
+                Path = "docs/README.md", ChangeType = "edit", Additions = 3, Deletions = 1,
+                Hunks = new List<DiffHunk>
+                {
+                    new()
+                    {
+                        OldStart = 1, OldCount = 1, NewStart = 1, NewCount = 3,
+                        Lines = new List<DiffLine> { new() { Op = '+', Text = "doc line" } }
+                    }
+                }
+            }
+        }
+    };
+
+    public GetPullRequestContentToolHandlerTests()
+    {
+        _dataProvider.GetFilesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(SampleFiles);
+        _dataProvider.GetDiffAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(SampleDiff);
+
+        _budgetResolver.Resolve(Arg.Any<int?>(), Arg.Any<string?>())
+            .Returns(new BudgetResolutionResult(200000, 140000, BudgetSource.Default, Array.Empty<string>()));
+        _tokenEstimator.EstimateFromStats(Arg.Any<int>(), Arg.Any<int>())
+            .Returns(500);
+        _fileClassifier.Classify(Arg.Any<string>())
+            .Returns(new FileClassification { Category = FileCategory.Source });
+
+        // Default: all 3 files on page 1
+        var pageSlice = new PageSlice(1, 0, 3,
+            new[]
+            {
+                new PageSliceItem(0, PackingItemStatus.Included, 500),
+                new PageSliceItem(1, PackingItemStatus.Included, 500),
+                new PageSliceItem(2, PackingItemStatus.Included, 500)
+            },
+            1500, 138500);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { pageSlice }, 1, 3));
+
+        _handler = new GetPullRequestContentToolHandler(
+            _dataProvider,
+            _budgetResolver,
+            _tokenEstimator,
+            _fileClassifier,
+            _pageAllocator,
+            NullLogger<GetPullRequestContentToolHandler>.Instance);
+    }
+
+    // --- Happy path ---
+
+    [Fact]
+    public async Task ExecuteAsync_SinglePage_ReturnsAllFiles()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(42, doc.RootElement.GetProperty("prNumber").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("pageNumber").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("totalPages").GetInt32());
+        Assert.Equal(3, doc.RootElement.GetProperty("files").GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsCorrectSummary()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        var summary = doc.RootElement.GetProperty("summary");
+        Assert.Equal(3, summary.GetProperty("filesOnPage").GetInt32());
+        Assert.Equal(3, summary.GetProperty("totalFiles").GetInt32());
+        Assert.Equal(1500, summary.GetProperty("estimatedTokens").GetInt32());
+        Assert.False(summary.GetProperty("hasMorePages").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsCategories()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        var categories = doc.RootElement.GetProperty("summary").GetProperty("categories");
+        Assert.Equal(3, categories.GetProperty("source").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultiplePages_ReturnsOnlyRequestedPage()
+    {
+        var slice1 = new PageSlice(1, 0, 2,
+            new[]
+            {
+                new PageSliceItem(0, PackingItemStatus.Included, 500),
+                new PageSliceItem(1, PackingItemStatus.Included, 500)
+            },
+            1000, 139000);
+        var slice2 = new PageSlice(2, 2, 3,
+            new[] { new PageSliceItem(2, PackingItemStatus.Included, 500) },
+            500, 139500);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { slice1, slice2 }, 2, 3));
+
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 2);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(2, doc.RootElement.GetProperty("pageNumber").GetInt32());
+        Assert.Equal(2, doc.RootElement.GetProperty("totalPages").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("files").GetArrayLength());
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("hasMorePages").GetBoolean() == false);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_HasMorePages_TrueWhenNotLastPage()
+    {
+        var slice1 = new PageSlice(1, 0, 2,
+            new[]
+            {
+                new PageSliceItem(0, PackingItemStatus.Included, 500),
+                new PageSliceItem(1, PackingItemStatus.Included, 500)
+            },
+            1000, 139000);
+        var slice2 = new PageSlice(2, 2, 3,
+            new[] { new PageSliceItem(2, PackingItemStatus.Included, 500) },
+            500, 139500);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { slice1, slice2 }, 2, 3));
+
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.GetProperty("summary").GetProperty("hasMorePages").GetBoolean());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FileChanges_HaveHunksAndLines()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1);
+
+        var doc = JsonDocument.Parse(json);
+        var firstFile = doc.RootElement.GetProperty("files")[0];
+        Assert.Equal("src/A.cs", firstFile.GetProperty("path").GetString());
+        Assert.True(firstFile.GetProperty("hunks").GetArrayLength() > 0);
+        var firstHunk = firstFile.GetProperty("hunks")[0];
+        Assert.True(firstHunk.GetProperty("lines").GetArrayLength() > 0);
+    }
+
+    // --- Error handling ---
+
+    [Fact]
+    public async Task ExecuteAsync_NullPrNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: null, pageNumber: 1));
+        Assert.Contains("prNumber", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullPageNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 42, pageNumber: null));
+        Assert.Contains("pageNumber", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ZeroPageNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 42, pageNumber: 0));
+        Assert.Contains("pageNumber must be >= 1", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PageExceedsTotalPages_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 42, pageNumber: 99));
+        Assert.Contains("exceeds total pages", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrNotFound_ThrowsMcpException()
+    {
+        _dataProvider.GetFilesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new PullRequestNotFoundException("Not found"));
+
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 999, pageNumber: 1));
+        Assert.Contains("Pull Request not found", ex.Message);
+    }
+
+    // --- Budget forwarding ---
+
+    [Fact]
+    public async Task ExecuteAsync_ForwardsBudgetParams()
+    {
+        await _handler.ExecuteAsync(prNumber: 42, pageNumber: 1, modelName: "gpt-4o", maxTokens: 50000);
+
+        _budgetResolver.Received(1).Resolve(50000, "gpt-4o");
+    }
+}

--- a/REBUSS.Pure.Tests/Tools/GetPullRequestMetadataToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetPullRequestMetadataToolHandlerTests.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Exceptions;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.Pagination;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Tools;
+
+namespace REBUSS.Pure.Tests.Tools;
+
+public class GetPullRequestMetadataToolHandlerTests
+{
+    private readonly IPullRequestDataProvider _dataProvider = Substitute.For<IPullRequestDataProvider>();
+    private readonly IContextBudgetResolver _budgetResolver = Substitute.For<IContextBudgetResolver>();
+    private readonly ITokenEstimator _tokenEstimator = Substitute.For<ITokenEstimator>();
+    private readonly IFileClassifier _fileClassifier = Substitute.For<IFileClassifier>();
+    private readonly IPageAllocator _pageAllocator = Substitute.For<IPageAllocator>();
+    private readonly GetPullRequestMetadataToolHandler _handler;
+
+    private static readonly FullPullRequestMetadata SampleMetadata = new()
+    {
+        PullRequestId = 42,
+        CodeReviewId = 100,
+        Title = "Fix the bug",
+        Description = "Some description",
+        Status = "active",
+        IsDraft = false,
+        AuthorLogin = "user1",
+        AuthorDisplayName = "User One",
+        CreatedDate = new DateTime(2025, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+        ClosedDate = null,
+        SourceBranch = "feature/x",
+        TargetBranch = "main",
+        LastMergeSourceCommitId = "abc123",
+        LastMergeTargetCommitId = "def456",
+        CommitShas = new List<string> { "abc123" },
+        ChangedFilesCount = 3,
+        Additions = 50,
+        Deletions = 10,
+        RepositoryFullName = "org/repo",
+        WebUrl = "https://example.com/pr/42"
+    };
+
+    private static readonly PullRequestFiles SampleFiles = new()
+    {
+        Files = new List<PullRequestFileInfo>
+        {
+            new() { Path = "src/A.cs", Additions = 30, Deletions = 5, Changes = 35, Extension = ".cs" },
+            new() { Path = "src/B.cs", Additions = 20, Deletions = 5, Changes = 25, Extension = ".cs" }
+        }
+    };
+
+    public GetPullRequestMetadataToolHandlerTests()
+    {
+        _dataProvider.GetMetadataAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(SampleMetadata);
+        _dataProvider.GetFilesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(SampleFiles);
+
+        _budgetResolver.Resolve(Arg.Any<int?>(), Arg.Any<string?>())
+            .Returns(new BudgetResolutionResult(200000, 140000, BudgetSource.Default, Array.Empty<string>()));
+        _tokenEstimator.EstimateFromStats(Arg.Any<int>(), Arg.Any<int>())
+            .Returns(500);
+        _fileClassifier.Classify(Arg.Any<string>())
+            .Returns(new FileClassification { Category = FileCategory.Source });
+
+        var pageSlice = new PageSlice(1, 0, 2,
+            new[] { new PageSliceItem(0, PackingItemStatus.Included, 500), new PageSliceItem(1, PackingItemStatus.Included, 500) },
+            1000, 139000);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { pageSlice }, 1, 2));
+
+        _handler = new GetPullRequestMetadataToolHandler(
+            _dataProvider,
+            _budgetResolver,
+            _tokenEstimator,
+            _fileClassifier,
+            _pageAllocator,
+            NullLogger<GetPullRequestMetadataToolHandler>.Instance);
+    }
+
+    // --- Existing behavior (backward compatibility) ---
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutBudgetParams_ReturnsMetadataWithoutPaging()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal(42, doc.RootElement.GetProperty("prNumber").GetInt32());
+        Assert.Equal("Fix the bug", doc.RootElement.GetProperty("title").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("contentPaging", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PreservesExistingFields()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.Equal("user1", doc.RootElement.GetProperty("author").GetProperty("login").GetString());
+        Assert.Equal("active", doc.RootElement.GetProperty("state").GetString());
+        Assert.Equal("main", doc.RootElement.GetProperty("base").GetProperty("ref").GetString());
+        Assert.Equal("feature/x", doc.RootElement.GetProperty("head").GetProperty("ref").GetString());
+        Assert.Equal(3, doc.RootElement.GetProperty("stats").GetProperty("changedFiles").GetInt32());
+    }
+
+    // --- Pagination info (new behavior) ---
+
+    [Fact]
+    public async Task ExecuteAsync_WithModelName_ReturnsContentPaging()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, modelName: "gpt-4o");
+
+        var doc = JsonDocument.Parse(json);
+        var paging = doc.RootElement.GetProperty("contentPaging");
+        Assert.Equal(1, paging.GetProperty("totalPages").GetInt32());
+        Assert.Equal(2, paging.GetProperty("totalFiles").GetInt32());
+        Assert.Equal(140000, paging.GetProperty("budgetPerPageTokens").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMaxTokens_ReturnsContentPaging()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, maxTokens: 50000);
+
+        var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("contentPaging", out _));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContentPaging_FilesByPage_HasCorrectShape()
+    {
+        var json = await _handler.ExecuteAsync(prNumber: 42, modelName: "gpt-4o");
+
+        var doc = JsonDocument.Parse(json);
+        var filesByPage = doc.RootElement.GetProperty("contentPaging").GetProperty("filesByPage");
+        Assert.Equal(1, filesByPage.GetArrayLength());
+        Assert.Equal(1, filesByPage[0].GetProperty("pageNumber").GetInt32());
+        Assert.Equal(2, filesByPage[0].GetProperty("fileCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ContentPaging_MultiplePages_AllPagesListed()
+    {
+        var slice1 = new PageSlice(1, 0, 1,
+            new[] { new PageSliceItem(0, PackingItemStatus.Included, 500) }, 500, 139500);
+        var slice2 = new PageSlice(2, 1, 2,
+            new[] { new PageSliceItem(1, PackingItemStatus.Included, 500) }, 500, 139500);
+        _pageAllocator.Allocate(Arg.Any<IReadOnlyList<PackingCandidate>>(), Arg.Any<int>())
+            .Returns(new PageAllocation(new[] { slice1, slice2 }, 2, 2));
+
+        var json = await _handler.ExecuteAsync(prNumber: 42, modelName: "gpt-4o");
+
+        var doc = JsonDocument.Parse(json);
+        var paging = doc.RootElement.GetProperty("contentPaging");
+        Assert.Equal(2, paging.GetProperty("totalPages").GetInt32());
+        var filesByPage = paging.GetProperty("filesByPage");
+        Assert.Equal(2, filesByPage.GetArrayLength());
+        Assert.Equal(1, filesByPage[0].GetProperty("fileCount").GetInt32());
+        Assert.Equal(1, filesByPage[1].GetProperty("fileCount").GetInt32());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPaging_CallsFileClassifierForEachFile()
+    {
+        await _handler.ExecuteAsync(prNumber: 42, modelName: "gpt-4o");
+
+        _fileClassifier.Received(2).Classify(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPaging_CallsEstimateFromStatsForEachFile()
+    {
+        await _handler.ExecuteAsync(prNumber: 42, modelName: "gpt-4o");
+
+        _tokenEstimator.Received(2).EstimateFromStats(Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    // --- Error handling ---
+
+    [Fact]
+    public async Task ExecuteAsync_NullPrNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: null));
+        Assert.Contains("Missing required parameter", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ZeroPrNumber_ThrowsMcpException()
+    {
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 0));
+        Assert.Contains("greater than 0", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PrNotFound_ThrowsMcpException()
+    {
+        _dataProvider.GetMetadataAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new PullRequestNotFoundException("PR not found"));
+
+        var ex = await Assert.ThrowsAsync<McpException>(
+            () => _handler.ExecuteAsync(prNumber: 999));
+        Assert.Contains("Pull Request not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DescriptionTruncation_WorksCorrectly()
+    {
+        var longDescription = new string('x', 1000);
+        _dataProvider.GetMetadataAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new FullPullRequestMetadata
+            {
+                Title = "Test",
+                Description = longDescription,
+                CommitShas = new List<string>()
+            });
+
+        var json = await _handler.ExecuteAsync(prNumber: 42);
+
+        var doc = JsonDocument.Parse(json);
+        var desc = doc.RootElement.GetProperty("description");
+        Assert.True(desc.GetProperty("isTruncated").GetBoolean());
+        Assert.Equal(800, desc.GetProperty("returnedLength").GetInt32());
+    }
+}

--- a/REBUSS.Pure/Cli/Prompts/review-pr.md
+++ b/REBUSS.Pure/Cli/Prompts/review-pr.md
@@ -48,60 +48,46 @@ Avoid focusing on minor style issues unless they affect correctness or maintaina
 
 Use the following MCP tools from `REBUSS.Pure`.
 
-### get_pr_metadata(prNumber)
+### get_pr_metadata(prNumber, [modelName], [maxTokens])
 
-Use **first**.
+Use **first**. Always pass `modelName` or `maxTokens` to enable pagination info.
 
 Purpose:
 - understand the scope of the PR
 - retrieve `base.sha` and `head.sha`
 - retrieve PR title, author and description
-- determine review strategy
+- obtain `contentPaging` — the total page count and per-page file breakdown
+
+The response includes a `contentPaging` section when budget parameters are provided:
+```json
+{
+  "contentPaging": {
+    "totalPages": 3,
+    "totalFiles": 42,
+    "budgetPerPageTokens": 89600,
+    "filesByPage": [
+      { "pageNumber": 1, "fileCount": 12 },
+      { "pageNumber": 2, "fileCount": 15 },
+      { "pageNumber": 3, "fileCount": 15 }
+    ]
+  }
+}
+```
 
 ---
 
-### get_pr_files(prNumber)
+### get_pr_content(prNumber, pageNumber, [modelName], [maxTokens])
 
-Use **after metadata**.
-
-Purpose:
-- retrieve the list of changed files
-- obtain per-file statistics (additions/deletions/changes)
-- determine which files to review first
-
-Use this to avoid loading the entire PR diff at once.
-
----
-
-### get_pr_diff(prNumber)
-
-Use for **small PRs** as a faster alternative to iterating `get_file_diff` over each file.
+**Primary review tool.** Use this to iterate through pages of review content.
 
 Purpose:
-- retrieve the complete structured diff for all changed files in a single call
-- get a quick overview of all changes at once
+- retrieve the structured diff for all files on a specific page
+- each page is pre-sized to fit within the context budget
+- use the same `modelName`/`maxTokens` as the metadata call for consistent page allocation
 
-The response is a structured JSON object containing per-file hunks. Each file includes `path`, `changeType`, `additions`, `deletions`, and a `hunks` array. Each hunk contains location metadata and ordered lines with operation types (`+`, `-`, ` `).
+The response includes per-file diffs with `path`, `changeType`, `additions`, `deletions`, `hunks`, and a `summary` with `filesOnPage`, `totalFiles`, `estimatedTokens`, `hasMorePages`, and `categories`.
 
-Some files may have their diff **automatically skipped** by the server (see *Skipped Diffs* below). Their `hunks` array will be empty and a `skipReason` field will explain why.
-
-Do not use for large PRs — prefer `get_file_diff` to keep context small.
-
----
-
-### get_file_diff(prNumber, path)
-
-Default method for reviewing code.
-
-Purpose:
-- retrieve the structured diff for a specific file
-- analyze changes with minimal context cost
-
-The response is a structured JSON object containing the file's `path`, `changeType`, `additions`, `deletions`, and a `hunks` array. Each hunk contains `oldStart`, `oldCount`, `newStart`, `newCount`, and ordered `lines` with an `op` field (`+`, `-`, ` `) and `text`.
-
-If the file belongs to a skip category (deleted, renamed, binary, generated, or full-file rewrite), the response contains a `skipReason` value and an empty `hunks` array. In that case, do not attempt to analyze the diff content — acknowledge the skip reason and move on.
-
-Always prefer this before retrieving full file content.
+Files may have their diff **automatically skipped** — their `hunks` array will be empty and a `skipReason` field will explain why (see *Skipped Diffs* below).
 
 ---
 
@@ -113,7 +99,6 @@ Purpose:
 - retrieve the full file content from a specific revision.
 
 Use:
-
 - `head.sha` to inspect the new implementation
 - `base.sha` to inspect the previous implementation
 
@@ -121,50 +106,54 @@ Do not retrieve full content for every file by default.
 
 ---
 
-# Mandatory Review Workflow
+### Legacy tools (available but not recommended for reviews)
 
-## Step 1 — Load metadata
+These tools remain available for specific use cases:
 
-- Before reviewing any PR, ALWAYS call `get_pr_metadata(prNumber)` first to confirm the PR title, author and branch.
-- NEVER infer PR content, title, or scope from the branch name or converstation history.
-- Treat any pre-existing summary/context about a PR as unverified until confirmed by 'get_pr_metadata'.
+- `get_pr_files(prNumber)` — list changed files with stats
+- `get_pr_diff(prNumber)` — full PR diff in one call (risk of context overflow)
+- `get_file_diff(prNumber, path)` — single-file diff
 
-Call:
-
-`get_pr_metadata(prNumber)`
-
-Use the result to determine:
-
-- PR size
-- number of changed files
-- number of commits
-- total additions/deletions
-- base SHA and head SHA
-- high-level intent of the change
+Prefer `get_pr_content` over these for reviews — it provides server-managed pagination.
 
 ---
 
-## Step 2 — Retrieve changed files
+# Mandatory Review Workflow
+
+## Step 1 — Load metadata with pagination info
+
+- Before reviewing any PR, ALWAYS call `get_pr_metadata` first.
+- NEVER infer PR content, title, or scope from the branch name or conversation history.
+- Treat any pre-existing summary/context about a PR as unverified until confirmed by `get_pr_metadata`.
 
 Call:
 
-`get_pr_files(prNumber)`
+`get_pr_metadata(prNumber, modelName: "<your model>")`
 
-Use this to:
+Use the result to determine:
 
-- list all changed files
-- determine review order
-- identify files that will have their diffs skipped (binary, generated, deleted, renamed)
-- prioritize important source code
+- PR size and intent
+- number of changed files
+- base SHA and head SHA
+- **total pages** from `contentPaging.totalPages`
 
-Preferred review order:
+---
 
-1. source files
-2. configuration files
-3. test files
-4. documentation
+## Step 2 — Iterate through content pages
 
-Do not request diffs for files that are clearly binary or generated — the server will skip them automatically, but avoiding unnecessary calls saves time.
+Loop from page 1 to `totalPages`:
+
+```
+for pageNumber in 1..totalPages:
+    response = get_pr_content(prNumber, pageNumber, modelName: "<your model>")
+    review each file in response.files
+    check response.summary.hasMorePages to confirm continuation
+```
+
+For each file on the page:
+- analyze the diff hunks for issues
+- note files with `skipReason` — do not analyze their content
+- use `get_file_content_at_ref` only when the diff lacks sufficient context
 
 ---
 
@@ -175,78 +164,21 @@ The diff provider **automatically skips** diff generation for certain files. Whe
 - a `skipReason` field explaining why (e.g. `"file deleted"`, `"file renamed"`, `"binary file"`, `"generated file"`, `"full file rewrite"`)
 - an empty `hunks` array
 
-Example skipped file in the structured response:
-
-```json
-{
-  "path": "lib/tool.dll",
-  "changeType": "add",
-  "skipReason": "binary file",
-  "additions": 0,
-  "deletions": 0,
-  "hunks": []
-}
-```
-
 ## Skip categories
 
 | Category | skipReason | When it applies |
 |---|---|---|
-| File deletions | `file deleted` | File was removed. No content is fetched. |
-| File renames | `file renamed` | Pure rename. Content diff would be misleading. |
-| Binary files | `binary file` | Detected by extension (`.dll`, `.png`, `.zip`, `.pdf`, etc.). |
-| Generated files | `generated file` | Detected by path (`/obj/`, `/bin/`, `.g.cs`, `.designer.cs`, lock files, etc.). |
-| Full-file rewrites | `full file rewrite` | Both versions exist (≥10 lines each) but every line changed — indicates formatting rewrite or tooling output. |
+| File deletions | `file deleted` | File was removed |
+| File renames | `file renamed` | Pure rename |
+| Binary files | `binary file` | Detected by extension |
+| Generated files | `generated file` | Detected by path |
+| Full-file rewrites | `full file rewrite` | Every line changed — formatting rewrite |
 
 ## How to handle skipped diffs
 
-- **Do not** try to analyze the diff content of a skipped file.
-- **Acknowledge** the skip in the review notes (e.g. "File `/lib/tool.dll` skipped: binary file").
-- For deleted files, note the deletion but do not request full content.
-- For renamed files, note the rename.
-- For binary and generated files, skip entirely unless there is a specific concern.
-- For full-file rewrites, consider requesting full file content via `get_file_content_at_ref` only if the file appears to be important source code.
-
----
-
-# Review Strategy
-
-Choose the strategy depending on PR size.
-
----
-
-## Small PR
-
-If the PR contains only a few files and limited changes:
-
-- call `get_pr_diff(prNumber)` to retrieve all changes in a single call
-- only retrieve full file content when necessary
-
----
-
-## Medium PR
-
-If the PR contains a moderate number of files:
-
-- prioritize high-value files first
-- review file-by-file using `get_file_diff`
-- retrieve full file content only when the patch lacks context
-- use tests only as supporting evidence
-
----
-
-## Large PR
-
-If the PR is large:
-
-- do NOT load the entire PR into context
-- review iteratively file-by-file
-- start with high-priority files
-- retrieve only the diff for each file
-- retrieve full file content only when necessary
-- focus on high-risk logic changes first
-
-If the PR is extremely large, explain that the review focuses on the most critical files.
+- **Do not** analyze the diff content of a skipped file.
+- **Acknowledge** the skip in the review notes.
+- For full-file rewrites of important source code, consider `get_file_content_at_ref`.
 
 ---
 
@@ -257,11 +189,7 @@ When using `get_file_content_at_ref`:
 1. Prefer `head.sha` to inspect the current implementation.
 2. Use `base.sha` only if comparing previous behavior is necessary.
 3. Never retrieve full file content for all files automatically.
-4. Avoid retrieving full content for:
-   - documentation
-   - generated files
-   - binary files
-   - trivial changes
+4. Avoid retrieving full content for documentation, generated files, binary files, or trivial changes.
 
 ---
 
@@ -336,10 +264,10 @@ Optional improvements that are helpful but not critical.
 
 Briefly mention:
 
+- which pages were reviewed
 - which files were reviewed in detail
 - whether full file content was required
-- whether review scope was limited due to PR size
-- which files had their diffs skipped by the server and why (use the `skipReason` value)
+- which files had their diffs skipped by the server and why
 
 ---
 

--- a/REBUSS.Pure/Cli/Prompts/self-review.md
+++ b/REBUSS.Pure/Cli/Prompts/self-review.md
@@ -6,10 +6,10 @@ This review MUST:
 - use only MCP tools from `REBUSS.Pure`
 - NEVER inspect files or project state directly from the editor or local workspace
 - NEVER reason about local changes without calling MCP tools
-- rely solely on `get_local_files` and `get_local_file_diff`
+- rely on `get_local_content` as the primary review tool
 - abort if MCP tools are unavailable
 
-If any required MCP tool is missing, respond with:  
+If any required MCP tool is missing, respond with:
 **"Cannot proceed: required MCP tools not available."**
 
 ---
@@ -27,94 +27,109 @@ No other input is needed to determine the scope.
 
 # Allowed MCP Tools (Strict)
 
-### `get_local_files([scope])`
-Call this **first**.
+### `get_local_content(pageNumber, [scope], [modelName], [maxTokens])`
+
+**Primary review tool.** Use this to iterate through pages of local change content.
 
 Purpose:
-- detect locally changed files
-- understand the scope and categories of changes
-- decide which files need further inspection
+- retrieve structured diffs for all files on a specific page
+- each page is pre-sized to fit within the context budget
+- the response includes `repositoryRoot`, `currentBranch`, `scope`, page info, and per-file diffs
+
+The first page response tells you the `totalPages` - loop through all pages.
+
+Start with page 1:
+```
+response = get_local_content(pageNumber: 1, scope: "staged")
+```
 
 The response includes:
-- repositoryRoot
-- scope
-- currentBranch
-- totalFiles
-- list of files with: path, status, additions, deletions, extension, classification, reviewPriority
-- summary by category (source / test / config / docs / binary / generated)
+- `repositoryRoot` - absolute path to the git repository
+- `currentBranch` - current branch name (null if detached HEAD)
+- `scope` - the scope used
+- `pageNumber` / `totalPages` - pagination info
+- `files` - array of structured diffs per file
+- `summary.filesOnPage`, `summary.totalFiles`, `summary.hasMorePages`, `summary.categories`
 
 ---
 
-### `get_local_file_diff(path, [scope])`
-Call **only after** `get_local_files`.
+### Legacy tools (available but not recommended)
 
-Purpose:
-- obtain structured diffs for selected files
-- minimize context consumption
+These tools remain available for specific use cases:
 
-Notes:
-- must reuse the SAME `scope` as used in `get_local_files`
-- files may be skipped with a `skipReason`
-- skipped diffs must NOT be analyzed
+- `get_local_files([scope])` - list changed files with stats (no diffs)
+- `get_local_file_diff(path, [scope])` - single-file diff
+
+Prefer `get_local_content` - it provides server-managed pagination and reduces tool calls.
 
 ---
 
 # Mandatory Workflow
 
-## Step 1 — List changed files
+## Step 1 - Retrieve first page of content
+
 Call:
 
-get_local_files([scope])
+`get_local_content(pageNumber: 1, scope: "staged")`
 
-Then:
-- note repositoryRoot and currentBranch  
-- read file categories and priorities  
-- decide which files are worth reviewing (source › config › tests › docs)
+From the response:
+- note `repositoryRoot` and `currentBranch`
+- note `totalPages` to plan iteration
+- review each file in the `files` array
+- check `summary.categories` for change distribution
 
 ---
 
-## Step 2 — Retrieve diffs only for relevant files
+## Step 2 - Iterate remaining pages
 
-For each file that merits actual review:
+If `summary.hasMorePages` is true, continue:
 
-get_local_file_diff(path, [scope])
+```
+for pageNumber in 2..totalPages:
+    response = get_local_content(pageNumber, scope: "staged")
+    review each file in response.files
+```
 
-Skip:
-- binary files  
-- generated files  
-- trivial changes  
-- files with `skipReason`  
+For each file:
+- analyze the diff hunks for issues
+- note files with `skipReason` - do not analyze their content
 
 ---
 
 # Review Priorities
 
 Order:
-1. High-priority source files  
-2. Other source files  
-3. Configuration files  
-4. Test files  
-5. Documentation  
+1. High-priority source files
+2. Other source files
+3. Configuration files
+4. Test files
+5. Documentation
 
 ---
 
 # What to Look For
 
 Check diffs for:
-- correctness issues  
-- potential bugs or regressions  
-- null safety problems  
-- concurrency hazards  
-- async/await correctness  
-- missing validation or error-handling  
-- unintended behavior changes  
-- performance regressions  
-- duplicated or fragile logic  
-- missing or insufficient tests  
+- correctness issues
+- potential bugs or regressions
+- null safety problems
+- concurrency hazards
+- async/await correctness
+- missing validation or error-handling
+- unintended behavior changes
+- performance regressions
+- duplicated or fragile logic
+- missing or insufficient tests
 
 For test changes:
-- ensure coverage matches modified logic  
-- confirm assertions are meaningful  
+- ensure coverage matches modified logic
+- confirm assertions are meaningful
+
+---
+
+# Skipped Diffs
+
+Files may have their diff skipped with a `skipReason` field (e.g. `"binary file"`, `"generated file"`, `"file deleted"`). Do not analyze their content - acknowledge the skip in review notes.
 
 ---
 
@@ -122,29 +137,30 @@ For test changes:
 
 ## Verdict
 Short summary including:
-- repository root  
-- current branch  
-- scope used  
-- number of files reviewed  
+- repository root
+- current branch
+- scope used
+- number of files reviewed
+- number of pages processed
 
 ---
 
 ## Critical Issues
 For each:
-- file path  
-- severity  
-- issue description  
-- why it matters  
-- recommended fix  
+- file path
+- severity
+- issue description
+- why it matters
+- recommended fix
 
 ---
 
 ## Important Improvements
 For each:
-- file path  
-- what to improve  
-- reason  
-- suggested correction  
+- file path
+- what to improve
+- reason
+- suggested correction
 
 ---
 
@@ -154,17 +170,18 @@ For each:
 
 ## Review Notes
 Include:
-- scope used  
-- which files were reviewed  
-- which files were skipped and why  
-- limitations due to large change sets (if applicable)  
+- scope used
+- which pages were reviewed
+- which files were reviewed
+- which files were skipped and why
+- limitations due to large change sets (if applicable)
 
 ---
 
 # Behavioral Requirements
 
-- Never infer file contents.  
-- Never analyze files outside MCP responses.  
-- Avoid unnecessary tool calls.  
-- Prefer fewer, higher-value insights.  
-- If something is uncertain, mark it as a potential risk.  
+- Never infer file contents.
+- Never analyze files outside MCP responses.
+- Avoid unnecessary tool calls.
+- Prefer fewer, higher-value insights.
+- If something is uncertain, mark it as a potential risk.

--- a/REBUSS.Pure/Services/ContextWindow/TokenEstimator.cs
+++ b/REBUSS.Pure/Services/ContextWindow/TokenEstimator.cs
@@ -13,6 +13,8 @@ namespace REBUSS.Pure.Services.ContextWindow;
 public sealed class TokenEstimator : ITokenEstimator
 {
     private const double DefaultCharsPerToken = 4.0;
+    private const int AvgTokensPerLine = 15;
+    private const int PerFileOverhead = 50;
 
     private readonly IOptions<ContextWindowOptions> _options;
     private readonly ILogger<TokenEstimator> _logger;
@@ -46,5 +48,11 @@ public sealed class TokenEstimator : ITokenEstimator
         var fitsWithinBudget = estimatedTokens <= safeBudgetTokens;
 
         return new TokenEstimationResult(estimatedTokens, percentageUsed, fitsWithinBudget);
+    }
+
+    public int EstimateFromStats(int additions, int deletions)
+    {
+        var lineCount = Math.Max(0, additions) + Math.Max(0, deletions);
+        return lineCount * AvgTokensPerLine + PerFileOverhead;
     }
 }

--- a/REBUSS.Pure/Tools/GetLocalContentToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetLocalContentToolHandler.cs
@@ -1,0 +1,205 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Services.LocalReview;
+using REBUSS.Pure.Services.ResponsePacking;
+using REBUSS.Pure.Tools.Models;
+
+namespace REBUSS.Pure.Tools
+{
+    /// <summary>
+    /// Handles the <c>get_local_content</c> MCP tool.
+    /// Returns diff content for a single page of local uncommitted changes.
+    /// Pages are computed via stat-based token estimation and deterministic page allocation.
+    /// </summary>
+    [McpServerToolType]
+    public class GetLocalContentToolHandler
+    {
+        private readonly ILocalReviewProvider _localProvider;
+        private readonly IContextBudgetResolver _budgetResolver;
+        private readonly ITokenEstimator _tokenEstimator;
+        private readonly IFileClassifier _fileClassifier;
+        private readonly IPageAllocator _pageAllocator;
+        private readonly ILogger<GetLocalContentToolHandler> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public GetLocalContentToolHandler(
+            ILocalReviewProvider localProvider,
+            IContextBudgetResolver budgetResolver,
+            ITokenEstimator tokenEstimator,
+            IFileClassifier fileClassifier,
+            IPageAllocator pageAllocator,
+            ILogger<GetLocalContentToolHandler> logger)
+        {
+            _localProvider = localProvider;
+            _budgetResolver = budgetResolver;
+            _tokenEstimator = tokenEstimator;
+            _fileClassifier = fileClassifier;
+            _pageAllocator = pageAllocator;
+            _logger = logger;
+        }
+
+        [McpServerTool(Name = "get_local_content"), Description(
+            "Returns the diff content for a specific page of local uncommitted changes. " +
+            "Pages are determined by stat-based token estimation and the provided budget. " +
+            "The tool computes page allocation internally — no separate metadata call is needed.")]
+        public async Task<string> ExecuteAsync(
+            [Description("Page number to retrieve (1-based)")] int? pageNumber = null,
+            [Description("Review scope: 'working-tree' (default), 'staged', or a branch/ref name")] string? scope = null,
+            [Description("Model name for context budget resolution")] string? modelName = null,
+            [Description("Explicit token budget override")] int? maxTokens = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (pageNumber == null)
+                throw new McpException("Missing required parameter: pageNumber");
+            if (pageNumber < 1)
+                throw new McpException("pageNumber must be >= 1");
+
+            try
+            {
+                var parsedScope = LocalReviewScope.Parse(scope);
+                _logger.LogInformation("[get_local_content] Entry: page {PageNumber}, scope={Scope}",
+                    pageNumber, parsedScope);
+
+                var sw = Stopwatch.StartNew();
+
+                var budget = _budgetResolver.Resolve(maxTokens, modelName);
+                var safeBudget = budget.SafeBudgetTokens;
+
+                // 1. Fetch lightweight file list and build page allocation
+                var localFiles = await _localProvider.GetFilesAsync(parsedScope, cancellationToken);
+                var candidates = BuildStatBasedCandidates(localFiles.Files);
+                candidates.Sort(PackingPriorityComparer.Instance);
+
+                var allocation = _pageAllocator.Allocate(candidates, safeBudget);
+
+                if (pageNumber > allocation.TotalPages)
+                    throw new McpException(
+                        $"pageNumber {pageNumber} exceeds total pages {allocation.TotalPages}");
+
+                var pageSlice = allocation.Pages[pageNumber.Value - 1];
+
+                // 2. Fetch diffs only for files on this page (per-file — inherently efficient)
+                var pageFiles = new List<StructuredFileChange>();
+                var pageCandidateIndices = new List<int>();
+                foreach (var item in pageSlice.Items)
+                {
+                    var candidate = candidates[item.OriginalIndex];
+                    pageCandidateIndices.Add(item.OriginalIndex);
+
+                    var fileDiff = await _localProvider.GetFileDiffAsync(
+                        candidate.Path, parsedScope, cancellationToken);
+
+                    var fileChange = fileDiff.Files.FirstOrDefault();
+                    if (fileChange != null)
+                        pageFiles.Add(MapToStructuredFileChange(fileChange));
+                }
+
+                // 3. Build category breakdown
+                var categories = BuildCategoryBreakdown(pageCandidateIndices, candidates);
+
+                var summary = new ContentPageSummary(
+                    FilesOnPage: pageFiles.Count,
+                    TotalFiles: allocation.TotalItems,
+                    EstimatedTokens: pageSlice.BudgetUsed,
+                    HasMorePages: pageNumber.Value < allocation.TotalPages,
+                    Categories: categories);
+
+                var result = new LocalContentPageResult(
+                    RepositoryRoot: localFiles.RepositoryRoot,
+                    CurrentBranch: localFiles.CurrentBranch,
+                    Scope: parsedScope.ToString(),
+                    PageNumber: pageNumber.Value,
+                    TotalPages: allocation.TotalPages,
+                    Files: pageFiles,
+                    Summary: summary);
+
+                var json = JsonSerializer.Serialize(result, JsonOptions);
+                sw.Stop();
+
+                _logger.LogInformation(
+                    "[get_local_content] Completed: page {Page}/{TotalPages}, {FileCount} files, {Chars} chars, {Ms}ms",
+                    pageNumber, allocation.TotalPages, pageFiles.Count, json.Length, sw.ElapsedMilliseconds);
+
+                return json;
+            }
+            catch (McpException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[get_local_content] Error (pageNumber={PageNumber}, scope={Scope})",
+                    pageNumber, scope);
+                throw new McpException($"Error retrieving local content: {ex.Message}");
+            }
+        }
+
+        // --- Helpers ---------------------------------------------------------------
+
+        private List<PackingCandidate> BuildStatBasedCandidates(List<PullRequestFileInfo> files)
+        {
+            var candidates = new List<PackingCandidate>(files.Count);
+            foreach (var file in files)
+            {
+                var estimatedTokens = _tokenEstimator.EstimateFromStats(file.Additions, file.Deletions);
+                var classification = _fileClassifier.Classify(file.Path);
+                candidates.Add(new PackingCandidate(
+                    file.Path,
+                    estimatedTokens,
+                    classification.Category,
+                    file.Additions + file.Deletions));
+            }
+            return candidates;
+        }
+
+        private static StructuredFileChange MapToStructuredFileChange(FileChange f)
+        {
+            return new StructuredFileChange
+            {
+                Path = f.Path,
+                ChangeType = f.ChangeType,
+                SkipReason = f.SkipReason,
+                Additions = f.Additions,
+                Deletions = f.Deletions,
+                Hunks = f.Hunks.Select(h => new StructuredHunk
+                {
+                    OldStart = h.OldStart,
+                    OldCount = h.OldCount,
+                    NewStart = h.NewStart,
+                    NewCount = h.NewCount,
+                    Lines = h.Lines.Select(l => new StructuredLine
+                    {
+                        Op = l.Op.ToString(),
+                        Text = l.Text
+                    }).ToList()
+                }).ToList()
+            };
+        }
+
+        private static Dictionary<string, int> BuildCategoryBreakdown(
+            List<int> pageCandidateIndices, List<PackingCandidate> candidates)
+        {
+            var categories = new Dictionary<string, int>();
+            foreach (var idx in pageCandidateIndices)
+            {
+                var key = candidates[idx].Category.ToString().ToLowerInvariant();
+                categories[key] = categories.GetValueOrDefault(key) + 1;
+            }
+            return categories;
+        }
+    }
+}

--- a/REBUSS.Pure/Tools/GetPullRequestContentToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetPullRequestContentToolHandler.cs
@@ -1,0 +1,208 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Exceptions;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.Pagination;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Services.ResponsePacking;
+using REBUSS.Pure.Tools.Models;
+
+namespace REBUSS.Pure.Tools
+{
+    /// <summary>
+    /// Handles the <c>get_pr_content</c> MCP tool.
+    /// Returns diff content for a single page of a pull request review.
+    /// Pages are computed via stat-based token estimation and deterministic page allocation.
+    /// </summary>
+    [McpServerToolType]
+    public class GetPullRequestContentToolHandler
+    {
+        private readonly IPullRequestDataProvider _dataProvider;
+        private readonly IContextBudgetResolver _budgetResolver;
+        private readonly ITokenEstimator _tokenEstimator;
+        private readonly IFileClassifier _fileClassifier;
+        private readonly IPageAllocator _pageAllocator;
+        private readonly ILogger<GetPullRequestContentToolHandler> _logger;
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public GetPullRequestContentToolHandler(
+            IPullRequestDataProvider dataProvider,
+            IContextBudgetResolver budgetResolver,
+            ITokenEstimator tokenEstimator,
+            IFileClassifier fileClassifier,
+            IPageAllocator pageAllocator,
+            ILogger<GetPullRequestContentToolHandler> logger)
+        {
+            _dataProvider = dataProvider;
+            _budgetResolver = budgetResolver;
+            _tokenEstimator = tokenEstimator;
+            _fileClassifier = fileClassifier;
+            _pageAllocator = pageAllocator;
+            _logger = logger;
+        }
+
+        [McpServerTool(Name = "get_pr_content"), Description(
+            "Returns the diff content for a specific page of a pull request review. " +
+            "Pages are determined by stat-based token estimation and the provided budget. " +
+            "Use get_pr_metadata with modelName/maxTokens to discover the total page count first.")]
+        public async Task<string> ExecuteAsync(
+            [Description("The Pull Request number/ID")] int? prNumber = null,
+            [Description("Page number to retrieve (1-based)")] int? pageNumber = null,
+            [Description("Model name for context budget resolution")] string? modelName = null,
+            [Description("Explicit token budget override")] int? maxTokens = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (prNumber == null)
+                throw new McpException("Missing required parameter: prNumber");
+            if (prNumber <= 0)
+                throw new McpException("prNumber must be greater than 0");
+            if (pageNumber == null)
+                throw new McpException("Missing required parameter: pageNumber");
+            if (pageNumber < 1)
+                throw new McpException("pageNumber must be >= 1");
+
+            try
+            {
+                _logger.LogInformation("[get_pr_content] Entry: PR #{PrNumber}, page {PageNumber}",
+                    prNumber, pageNumber);
+                var sw = Stopwatch.StartNew();
+
+                var budget = _budgetResolver.Resolve(maxTokens, modelName);
+                var safeBudget = budget.SafeBudgetTokens;
+
+                // 1. Fetch lightweight file list and build page allocation
+                var files = await _dataProvider.GetFilesAsync(prNumber.Value, cancellationToken);
+                var candidates = BuildStatBasedCandidates(files.Files);
+                candidates.Sort(PackingPriorityComparer.Instance);
+
+                var allocation = _pageAllocator.Allocate(candidates, safeBudget);
+
+                if (pageNumber > allocation.TotalPages)
+                    throw new McpException(
+                        $"pageNumber {pageNumber} exceeds total pages {allocation.TotalPages}");
+
+                var pageSlice = allocation.Pages[pageNumber.Value - 1];
+
+                // 2. Collect file paths on this page
+                var pageFilePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var item in pageSlice.Items)
+                    pageFilePaths.Add(candidates[item.OriginalIndex].Path);
+
+                // 3. Fetch full diff and filter to page files
+                var diff = await _dataProvider.GetDiffAsync(prNumber.Value, cancellationToken);
+                var pageFiles = BuildPageFileChanges(diff, pageFilePaths);
+
+                // 4. Build category breakdown
+                var categories = BuildCategoryBreakdown(pageFilePaths, candidates);
+
+                var summary = new ContentPageSummary(
+                    FilesOnPage: pageFiles.Count,
+                    TotalFiles: allocation.TotalItems,
+                    EstimatedTokens: pageSlice.BudgetUsed,
+                    HasMorePages: pageNumber.Value < allocation.TotalPages,
+                    Categories: categories);
+
+                var result = new PullRequestContentPageResult(
+                    PrNumber: prNumber.Value,
+                    PageNumber: pageNumber.Value,
+                    TotalPages: allocation.TotalPages,
+                    Files: pageFiles,
+                    Summary: summary);
+
+                var json = JsonSerializer.Serialize(result, JsonOptions);
+                sw.Stop();
+
+                _logger.LogInformation(
+                    "[get_pr_content] Completed: PR #{PrNumber}, page {Page}/{TotalPages}, {FileCount} files, {Chars} chars, {Ms}ms",
+                    prNumber, pageNumber, allocation.TotalPages, pageFiles.Count, json.Length, sw.ElapsedMilliseconds);
+
+                return json;
+            }
+            catch (PullRequestNotFoundException ex)
+            {
+                _logger.LogWarning(ex, "[get_pr_content] PR not found (prNumber={PrNumber})", prNumber);
+                throw new McpException($"Pull Request not found: {ex.Message}");
+            }
+            catch (McpException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "[get_pr_content] Error (prNumber={PrNumber}, pageNumber={PageNumber})",
+                    prNumber, pageNumber);
+                throw new McpException($"Error retrieving PR content: {ex.Message}");
+            }
+        }
+
+        // --- Helpers ---------------------------------------------------------------
+
+        private List<PackingCandidate> BuildStatBasedCandidates(List<PullRequestFileInfo> files)
+        {
+            var candidates = new List<PackingCandidate>(files.Count);
+            foreach (var file in files)
+            {
+                var estimatedTokens = _tokenEstimator.EstimateFromStats(file.Additions, file.Deletions);
+                var classification = _fileClassifier.Classify(file.Path);
+                candidates.Add(new PackingCandidate(
+                    file.Path,
+                    estimatedTokens,
+                    classification.Category,
+                    file.Additions + file.Deletions));
+            }
+            return candidates;
+        }
+
+        private static List<StructuredFileChange> BuildPageFileChanges(
+            PullRequestDiff diff, HashSet<string> pageFilePaths)
+        {
+            return diff.Files
+                .Where(f => pageFilePaths.Contains(f.Path))
+                .Select(f => new StructuredFileChange
+                {
+                    Path = f.Path,
+                    ChangeType = f.ChangeType,
+                    SkipReason = f.SkipReason,
+                    Additions = f.Additions,
+                    Deletions = f.Deletions,
+                    Hunks = f.Hunks.Select(h => new StructuredHunk
+                    {
+                        OldStart = h.OldStart,
+                        OldCount = h.OldCount,
+                        NewStart = h.NewStart,
+                        NewCount = h.NewCount,
+                        Lines = h.Lines.Select(l => new StructuredLine
+                        {
+                            Op = l.Op.ToString(),
+                            Text = l.Text
+                        }).ToList()
+                    }).ToList()
+                }).ToList();
+        }
+
+        private static Dictionary<string, int> BuildCategoryBreakdown(
+            HashSet<string> pageFilePaths, List<PackingCandidate> candidates)
+        {
+            var categories = new Dictionary<string, int>();
+            foreach (var candidate in candidates)
+            {
+                if (!pageFilePaths.Contains(candidate.Path)) continue;
+                var key = candidate.Category.ToString().ToLowerInvariant();
+                categories[key] = categories.GetValueOrDefault(key) + 1;
+            }
+            return categories;
+        }
+    }
+}

--- a/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
@@ -6,6 +6,9 @@ using ModelContextProtocol.Server;
 using REBUSS.Pure.Core;
 using REBUSS.Pure.Core.Exceptions;
 using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Shared;
+using REBUSS.Pure.Services.ResponsePacking;
 using REBUSS.Pure.Tools.Models;
 using System.Text.Json;
 
@@ -15,11 +18,16 @@ namespace REBUSS.Pure.Tools
     /// Handles the execution of the get_pr_metadata MCP tool.
     /// Validates input, delegates to <see cref="IPullRequestMetadataProvider"/>,
     /// and formats the result as a structured JSON response.
+    /// When budget parameters are provided, also computes pagination info.
     /// </summary>
     [McpServerToolType]
     public class GetPullRequestMetadataToolHandler
     {
         private readonly IPullRequestDataProvider _metadataProvider;
+        private readonly IContextBudgetResolver _budgetResolver;
+        private readonly ITokenEstimator _tokenEstimator;
+        private readonly IFileClassifier _fileClassifier;
+        private readonly IPageAllocator _pageAllocator;
         private readonly ILogger<GetPullRequestMetadataToolHandler> _logger;
 
         private const int MaxDescriptionLength = 800;
@@ -33,18 +41,30 @@ namespace REBUSS.Pure.Tools
 
         public GetPullRequestMetadataToolHandler(
             IPullRequestDataProvider metadataProvider,
+            IContextBudgetResolver budgetResolver,
+            ITokenEstimator tokenEstimator,
+            IFileClassifier fileClassifier,
+            IPageAllocator pageAllocator,
             ILogger<GetPullRequestMetadataToolHandler> logger)
         {
             _metadataProvider = metadataProvider;
+            _budgetResolver = budgetResolver;
+            _tokenEstimator = tokenEstimator;
+            _fileClassifier = fileClassifier;
+            _pageAllocator = pageAllocator;
             _logger = logger;
         }
 
         [McpServerTool(Name = "get_pr_metadata"), Description(
             "Retrieves metadata for a specific Pull Request. " +
             "Returns a JSON object with PR details including title, author, state, " +
-            "branches, stats, commit SHAs, and description.")]
+            "branches, stats, commit SHAs, and description. " +
+            "When modelName or maxTokens is provided, also returns contentPaging " +
+            "with page count and per-page file breakdown for use with get_pr_content.")]
         public async Task<string> ExecuteAsync(
             [Description("The Pull Request number/ID to retrieve metadata for")] int? prNumber = null,
+            [Description("Model name for context budget resolution (e.g. 'gpt-4o'). Triggers pagination info.")] string? modelName = null,
+            [Description("Explicit token budget override. Triggers pagination info.")] int? maxTokens = null,
             CancellationToken cancellationToken = default)
         {
             if (prNumber != null && prNumber <= 0)
@@ -60,6 +80,14 @@ namespace REBUSS.Pure.Tools
 
                 var metadata = await _metadataProvider.GetMetadataAsync(prNumber.Value, cancellationToken);
                 var result = BuildMetadataResult(prNumber.Value, metadata);
+
+                // Compute pagination info when budget parameters are provided
+                if (modelName != null || maxTokens != null)
+                {
+                    var pagingInfo = await BuildContentPagingInfoAsync(
+                        prNumber.Value, modelName, maxTokens, cancellationToken);
+                    result.ContentPaging = pagingInfo;
+                }
 
                 var json = JsonSerializer.Serialize(result, JsonOptions);
                 sw.Stop();
@@ -83,6 +111,48 @@ namespace REBUSS.Pure.Tools
                 _logger.LogError(ex, "[get_pr_metadata] Error (prNumber={PrNumber})", prNumber);
                 throw new McpException($"Error retrieving PR metadata: {ex.Message}");
             }
+        }
+
+        // --- Pagination info builder -----------------------------------------------
+
+        private async Task<ContentPagingInfo> BuildContentPagingInfoAsync(
+            int prNumber, string? modelName, int? maxTokens, CancellationToken ct)
+        {
+            var files = await _metadataProvider.GetFilesAsync(prNumber, ct);
+
+            var budget = _budgetResolver.Resolve(maxTokens, modelName);
+            var safeBudget = budget.SafeBudgetTokens;
+
+            var candidates = BuildStatBasedCandidates(files.Files);
+            candidates.Sort(PackingPriorityComparer.Instance);
+
+            var allocation = _pageAllocator.Allocate(candidates, safeBudget);
+
+            var filesByPage = allocation.Pages
+                .Select(p => new PageFileCount(p.PageNumber, p.Items.Count))
+                .ToList();
+
+            return new ContentPagingInfo(
+                TotalPages: allocation.TotalPages,
+                TotalFiles: allocation.TotalItems,
+                BudgetPerPageTokens: safeBudget,
+                FilesByPage: filesByPage);
+        }
+
+        private List<PackingCandidate> BuildStatBasedCandidates(List<PullRequestFileInfo> files)
+        {
+            var candidates = new List<PackingCandidate>(files.Count);
+            foreach (var file in files)
+            {
+                var estimatedTokens = _tokenEstimator.EstimateFromStats(file.Additions, file.Deletions);
+                var classification = _fileClassifier.Classify(file.Path);
+                candidates.Add(new PackingCandidate(
+                    file.Path,
+                    estimatedTokens,
+                    classification.Category,
+                    file.Additions + file.Deletions));
+            }
+            return candidates;
         }
 
         // --- Result builder -------------------------------------------------------

--- a/REBUSS.Pure/Tools/Models/ContentPagingInfo.cs
+++ b/REBUSS.Pure/Tools/Models/ContentPagingInfo.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace REBUSS.Pure.Tools.Models;
+
+/// <summary>
+/// Pagination overview included in <c>get_pr_metadata</c> response when budget
+/// parameters are provided. Describes how review content would be paginated.
+/// </summary>
+public sealed record ContentPagingInfo(
+    [property: JsonPropertyName("totalPages")] int TotalPages,
+    [property: JsonPropertyName("totalFiles")] int TotalFiles,
+    [property: JsonPropertyName("budgetPerPageTokens")] int BudgetPerPageTokens,
+    [property: JsonPropertyName("filesByPage")] IReadOnlyList<PageFileCount> FilesByPage
+);
+
+/// <summary>
+/// Per-page file count in the <see cref="ContentPagingInfo"/> breakdown.
+/// </summary>
+public sealed record PageFileCount(
+    [property: JsonPropertyName("pageNumber")] int PageNumber,
+    [property: JsonPropertyName("fileCount")] int FileCount
+);

--- a/REBUSS.Pure/Tools/Models/LocalContentPageResult.cs
+++ b/REBUSS.Pure/Tools/Models/LocalContentPageResult.cs
@@ -1,0 +1,17 @@
+using System.Text.Json.Serialization;
+
+namespace REBUSS.Pure.Tools.Models;
+
+/// <summary>
+/// Response DTO for the <c>get_local_content</c> tool.
+/// Contains diff content for a single page of local changes.
+/// </summary>
+public sealed record LocalContentPageResult(
+    [property: JsonPropertyName("repositoryRoot")] string RepositoryRoot,
+    [property: JsonPropertyName("currentBranch")] string? CurrentBranch,
+    [property: JsonPropertyName("scope")] string Scope,
+    [property: JsonPropertyName("pageNumber")] int PageNumber,
+    [property: JsonPropertyName("totalPages")] int TotalPages,
+    [property: JsonPropertyName("files")] IReadOnlyList<StructuredFileChange> Files,
+    [property: JsonPropertyName("summary")] ContentPageSummary Summary
+);

--- a/REBUSS.Pure/Tools/Models/PullRequestContentPageResult.cs
+++ b/REBUSS.Pure/Tools/Models/PullRequestContentPageResult.cs
@@ -1,0 +1,27 @@
+using System.Text.Json.Serialization;
+
+namespace REBUSS.Pure.Tools.Models;
+
+/// <summary>
+/// Response DTO for the <c>get_pr_content</c> tool.
+/// Contains diff content for a single page of a pull request.
+/// </summary>
+public sealed record PullRequestContentPageResult(
+    [property: JsonPropertyName("prNumber")] int PrNumber,
+    [property: JsonPropertyName("pageNumber")] int PageNumber,
+    [property: JsonPropertyName("totalPages")] int TotalPages,
+    [property: JsonPropertyName("files")] IReadOnlyList<StructuredFileChange> Files,
+    [property: JsonPropertyName("summary")] ContentPageSummary Summary
+);
+
+/// <summary>
+/// Summary section shared by <see cref="PullRequestContentPageResult"/>
+/// and <see cref="LocalContentPageResult"/>.
+/// </summary>
+public sealed record ContentPageSummary(
+    [property: JsonPropertyName("filesOnPage")] int FilesOnPage,
+    [property: JsonPropertyName("totalFiles")] int TotalFiles,
+    [property: JsonPropertyName("estimatedTokens")] int EstimatedTokens,
+    [property: JsonPropertyName("hasMorePages")] bool HasMorePages,
+    [property: JsonPropertyName("categories")] IReadOnlyDictionary<string, int> Categories
+);

--- a/REBUSS.Pure/Tools/Models/PullRequestMetadataResult.cs
+++ b/REBUSS.Pure/Tools/Models/PullRequestMetadataResult.cs
@@ -48,6 +48,9 @@ namespace REBUSS.Pure.Tools.Models
 
         [JsonPropertyName("source")]
         public SourceInfo Source { get; set; } = new();
+
+        [JsonPropertyName("contentPaging")]
+        public ContentPagingInfo? ContentPaging { get; set; }
     }
 
     public class AuthorInfo


### PR DESCRIPTION
- Add get_pr_content MCP tool: returns paginated diff content per page
- Add get_local_content MCP tool: returns paginated local diff per page
- Extend get_pr_metadata with contentPaging when budget params provided
- Add stat-based token estimation (EstimateFromStats) to ITokenEstimator
- Add ContentPagingInfo, PullRequestContentPageResult, LocalContentPageResult DTOs
- Redesign review-pr.md prompt for metadata + content page loop workflow
- Redesign self-review.md prompt for local content page loop workflow
- Update smoke tests: 7->9 tools, add pageNumber property assertions
- Add 42 new unit tests (14 metadata + 12 PR content + 12 local content + 5 estimator)
- Update Contracts.md and CodebaseUnderstanding.md documentation