### PR TITLE
Always emit unified-diff hunk headers in file diffs

### DIFF
--- a/.github/CodebaseUnderstanding.md
+++ b/.github/CodebaseUnderstanding.md
@@ -69,7 +69,7 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 |---|---|---|
 | `REBUSS.Pure.Core\Shared\DiffEdit.cs` | Line-level edit operation | � (`readonly record struct DiffEdit`) |
 | `REBUSS.Pure.Core\Shared\IDiffAlgorithm.cs` | Interface: line-level diff algorithm | `DiffEdit` |
-| `REBUSS.Pure.Core\Shared\DiffPlexDiffAlgorithm.cs` | Myers-based diff algorithm backed by DiffPlex NuGet library; includes `Debug.Assert` invariant checks for context gap and trailing line alignment | `IDiffAlgorithm`, `DiffEdit`, `DiffPlex.Differ` |
+| `REBUSS.Pure.Core\Shared\DiffPlexDiffAlgorithm.cs` | Myers-based diff algorithm backed by DiffPlex NuGet library; uses a `private static readonly Differ` instance (thread-safe, shared); throws `InvalidOperationException` for invariant violations (context gap mismatch, trailing line count mismatch) | `IDiffAlgorithm`, `DiffEdit`, `DiffPlex.Differ` |
 | `REBUSS.Pure.Core\Shared\IStructuredDiffBuilder.cs` | Interface: produces `List<DiffHunk>` | `DiffHunk` |
 | `REBUSS.Pure.Core\Shared\StructuredDiffBuilder.cs` | Builds structured hunks from base/target content | `IStructuredDiffBuilder`, `IDiffAlgorithm`, `DiffHunk`, `DiffLine`, `DiffEdit` |
 | `REBUSS.Pure.Core\Shared\IFileClassifier.cs` | Interface: file classifier | `FileClassification` |

--- a/.github/Contracts.md
+++ b/.github/Contracts.md
@@ -21,8 +21,8 @@ Wire format example (diff tool, 2 files + manifest):
   "jsonrpc": "2.0", "id": 1,
   "result": {
     "content": [
-      {"type":"text","text":"=== src/Foo.cs (edit: +10 -3) ===\n +added line\n-removed line\n context"},
-      {"type":"text","text":"=== src/Bar.cs (edit: +2 -0) ===\n +another line"},
+      {"type":"text","text":"=== src/Foo.cs (edit: +10 -3) ===\n@@ -1,5 +1,7 @@\n +added line\n-removed line\n context"},
+      {"type":"text","text":"=== src/Bar.cs (edit: +2 -0) ===\n@@ -1,3 +1,5 @@\n +another line"},
       {"type":"text","text":"Manifest:\n  src/Foo.cs                                                    ~  150 tokens  Included   Source\nBudget: 300/140000 tokens (0%)"}
     ]
   }
@@ -274,8 +274,11 @@ Auto-generated from `GetPullRequestDiffToolHandler.ExecuteAsync` signature. All 
 
 **Block 1..N:** one `TextContentBlock` per file
 
+Each file block starts with a `=== path (changeType: +additions -deletions) ===` header, followed by one or more hunks. Each hunk begins with a unified-diff `@@ -oldStart,oldCount +newStart,newCount @@` header line, then `+`/`-`/` `-prefixed content lines:
+
 ```
 === src/Cache/CacheService.cs (edit: +5 -2) ===
+@@ -10,4 +10,5 @@
  public class CacheService
 -    private int _ttl = 60;
 +    private int _ttl = 300;
@@ -436,10 +439,11 @@ Auto-generated from `GetPullRequestContentToolHandler.ExecuteAsync` signature. A
 
 #### Output — plain text blocks
 
-**Block 1..N:** one `TextContentBlock` per file (same diff format as `get_pr_diff`)
+**Block 1..N:** one `TextContentBlock` per file (same diff format as `get_pr_diff`, with `@@ -oldStart,oldCount +newStart,newCount @@` hunk headers)
 
 ```
 === src/Cache/CacheService.cs (edit: +5 -2) ===
+@@ -10,4 +10,5 @@
  public class CacheService
 -    private int _ttl = 60;
 +    private int _ttl = 300;

--- a/REBUSS.Pure.Core/Shared/DiffPlexDiffAlgorithm.cs
+++ b/REBUSS.Pure.Core/Shared/DiffPlexDiffAlgorithm.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using DiffPlex;
 
 namespace REBUSS.Pure.Core.Shared;
@@ -9,14 +8,14 @@ namespace REBUSS.Pure.Core.Shared;
 /// </summary>
 public class DiffPlexDiffAlgorithm : IDiffAlgorithm
 {
+    private static readonly Differ Differ = new();
+
     public IReadOnlyList<DiffEdit> ComputeEdits(string[] oldLines, string[] newLines)
     {
-        var differ = new Differ();
-
         var oldText = string.Join('\n', oldLines);
         var newText = string.Join('\n', newLines);
 
-        var diffResult = differ.CreateLineDiffs(oldText, newText, ignoreWhitespace: false);
+        var diffResult = Differ.CreateLineDiffs(oldText, newText, ignoreWhitespace: false);
 
         var edits = new List<DiffEdit>(oldLines.Length + newLines.Length);
         int oldIdx = 0;
@@ -25,8 +24,12 @@ public class DiffPlexDiffAlgorithm : IDiffAlgorithm
         foreach (var block in diffResult.DiffBlocks)
         {
             // Context lines before this block — gaps must be equal on both sides.
-            Debug.Assert(block.DeleteStartA - oldIdx == block.InsertStartB - newIdx,
-                "Context gap mismatch — diff block indices drifted.");
+            if (block.DeleteStartA - oldIdx != block.InsertStartB - newIdx)
+            {
+                throw new InvalidOperationException(
+                    $"Context gap mismatch — diff block indices drifted. " +
+                    $"Old gap: {block.DeleteStartA - oldIdx}, New gap: {block.InsertStartB - newIdx}.");
+            }
 
             int contextCount = block.DeleteStartA - oldIdx;
             for (int i = 0; i < contextCount; i++)
@@ -42,8 +45,12 @@ public class DiffPlexDiffAlgorithm : IDiffAlgorithm
         }
 
         // Trailing context lines — remaining counts must match.
-        Debug.Assert(oldLines.Length - oldIdx == newLines.Length - newIdx,
-            "Trailing context mismatch — remaining old/new line counts differ.");
+        if (oldLines.Length - oldIdx != newLines.Length - newIdx)
+        {
+            throw new InvalidOperationException(
+                $"Trailing context mismatch — remaining old/new line counts differ. " +
+                $"Old remaining: {oldLines.Length - oldIdx}, New remaining: {newLines.Length - newIdx}.");
+        }
 
         while (oldIdx < oldLines.Length && newIdx < newLines.Length)
             edits.Add(new DiffEdit(' ', oldIdx++, newIdx++));

--- a/REBUSS.Pure.SmokeTests/Contracts/AzureDevOps/AdoDiffContractTests.cs
+++ b/REBUSS.Pure.SmokeTests/Contracts/AzureDevOps/AdoDiffContractTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using REBUSS.Pure.SmokeTests.Expectations;
 using REBUSS.Pure.SmokeTests.Infrastructure;
 
@@ -65,6 +66,7 @@ public class AdoDiffContractTests
         var content = response.GetAllToolText();
 
         Assert.Contains("===", content);
+        Assert.Matches(new Regex(@"@@ -\d+,\d+ \+\d+,\d+ @@"), content);
     }
 
     [SkippableFact]
@@ -76,7 +78,18 @@ public class AdoDiffContractTests
             "get_pr_diff", new { prNumber = TestSettings.AdoPrNumber });
         var content = response.GetAllToolText();
 
-        Assert.True(content.Contains("+", StringComparison.Ordinal) || content.Contains("-", StringComparison.Ordinal));
+        var diffLines = content.Split('\n')
+            .Where(l => l.Length > 0 && !l.StartsWith("===") && !l.StartsWith("@@ ") &&
+                        !l.StartsWith("Manifest") && !l.StartsWith("Budget") &&
+                        !l.StartsWith("Reason:") && !l.StartsWith("---") &&
+                        !l.TrimStart().StartsWith('~'))
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+
+        Assert.NotEmpty(diffLines);
+        Assert.All(diffLines, line =>
+            Assert.True(line.StartsWith('+') || line.StartsWith('-') || line.StartsWith(' '),
+                $"Diff line has invalid prefix: '{line}'"));
     }
 
     [SkippableFact]

--- a/REBUSS.Pure.SmokeTests/Contracts/GitHub/GitHubDiffContractTests.cs
+++ b/REBUSS.Pure.SmokeTests/Contracts/GitHub/GitHubDiffContractTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using REBUSS.Pure.SmokeTests.Expectations;
 using REBUSS.Pure.SmokeTests.Infrastructure;
 
@@ -65,6 +66,7 @@ public class GitHubDiffContractTests
         var content = response.GetAllToolText();
 
         Assert.Contains("===", content);
+        Assert.Matches(new Regex(@"@@ -\d+,\d+ \+\d+,\d+ @@"), content);
     }
 
     [SkippableFact]
@@ -76,7 +78,18 @@ public class GitHubDiffContractTests
             "get_pr_diff", new { prNumber = TestSettings.GhPrNumber });
         var content = response.GetAllToolText();
 
-        Assert.True(content.Contains("+", StringComparison.Ordinal) || content.Contains("-", StringComparison.Ordinal));
+        var diffLines = content.Split('\n')
+            .Where(l => l.Length > 0 && !l.StartsWith("===") && !l.StartsWith("@@ ") &&
+                        !l.StartsWith("Manifest") && !l.StartsWith("Budget") &&
+                        !l.StartsWith("Reason:") && !l.StartsWith("---") &&
+                        !l.TrimStart().StartsWith('~'))
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+
+        Assert.NotEmpty(diffLines);
+        Assert.All(diffLines, line =>
+            Assert.True(line.StartsWith('+') || line.StartsWith('-') || line.StartsWith(' '),
+                $"Diff line has invalid prefix: '{line}'"));
     }
 
     [SkippableFact]

--- a/REBUSS.Pure.Tests/Tools/GetFileDiffToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetFileDiffToolHandlerTests.cs
@@ -86,6 +86,7 @@ public class GetFileDiffToolHandlerTests
 
         Assert.NotEmpty(blocks);
         Assert.Contains("/src/A.cs", text);
+        Assert.Contains("@@ -1,1 +1,1 @@", text);
         Assert.Contains("-old", text);
         Assert.Contains("+new", text);
     }

--- a/REBUSS.Pure.Tests/Tools/GetPullRequestDiffToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetPullRequestDiffToolHandlerTests.cs
@@ -101,6 +101,7 @@ public class GetPullRequestDiffToolHandlerTests
 
         Assert.NotEmpty(blocks);
         Assert.Contains("/src/A.cs", text);
+        Assert.Contains("@@ -1,1 +1,1 @@", text);
         Assert.Contains("-old", text);
         Assert.Contains("+new", text);
     }

--- a/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
+++ b/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
@@ -39,12 +39,14 @@ internal static class PlainTextFormatter
     }
 
     /// <summary>
-    /// Formats a single diff hunk. Used both for output and for token-count
-    /// estimation in <see cref="ToolHandlerHelpers.TruncateHunks"/>.
+    /// Formats a single diff hunk with a unified-diff <c>@@</c> header line.
+    /// Used both for output and for token-count estimation in
+    /// <see cref="ToolHandlerHelpers.TruncateHunks"/>.
     /// </summary>
     public static string FormatHunk(StructuredHunk hunk)
     {
         var sb = new StringBuilder();
+        sb.AppendLine($"@@ -{hunk.OldStart},{hunk.OldCount} +{hunk.NewStart},{hunk.NewCount} @@");
         foreach (var line in hunk.Lines)
         {
             var prefix = line.Op switch { "+" => "+", "-" => "-", _ => " " };
@@ -193,8 +195,12 @@ internal static class PlainTextFormatter
 
         if (staleness != null)
         {
-            var orig = staleness.OriginalFingerprint?[..Math.Min(8, staleness.OriginalFingerprint.Length)] ?? "?";
-            var curr = staleness.CurrentFingerprint?[..Math.Min(8, staleness.CurrentFingerprint.Length)] ?? "?";
+            var orig = staleness.OriginalFingerprint is { } origFp
+                ? origFp[..Math.Min(8, origFp.Length)]
+                : "?";
+            var curr = staleness.CurrentFingerprint is { } currFp
+                ? currFp[..Math.Min(8, currFp.Length)]
+                : "?";
             parts.Add($"STALE: head changed ({orig}\u2026 \u2192 {curr}\u2026)");
         }
 


### PR DESCRIPTION
Diff output now includes unified-diff hunk headers (e.g., @@ -1,2 +1,3 @@) for every hunk, even in single-hunk or small diffs, across both get_pr_diff and get_pr_content tools. Updated PlainTextFormatter to prepend these headers, and revised contract documentation and tests (AdoDiffContractTests, GitHubDiffContractTests, GetFileDiffToolHandlerTests, GetPullRequestDiffToolHandlerTests) to assert their presence and validate diff line prefixes. DiffPlexDiffAlgorithm now uses a static Differ instance and throws InvalidOperationException for invariant violations. Minor code cleanups and a PowerShell script for test file generation are also included.