### PR TITLE
Add stateful PR review session (feature 012)

### DIFF
--- a/.github/CodebaseUnderstanding.md
+++ b/.github/CodebaseUnderstanding.md
@@ -445,6 +445,24 @@ Note: As of the plain-text ContentBlock refactor, most JSON output DTOs have bee
 | `.github\ExtensionRecipes.md` | Detailed extension cookbook: code templates, reference implementations, validation checklists, common pitfalls for each extension pattern |
 | `.github\Contracts.md` | Complete MCP tool contract reference: input schemas, output JSON examples, error formats, serialization pipeline, shared DTOs, enum values |
 
+### Stateful PR Review Session — feature 012 (`REBUSS.Pure\Services\ReviewSession\`)
+
+| File | Role |
+|---|---|
+| `Services\ReviewSession\ReviewItemStatus.cs` | Enum for per-file lifecycle: `Pending` → `DeliveredPartial` → `DeliveredAwaitingObservation` → `ReviewedComplete` \| `SkippedWithReason` |
+| `Services\ReviewSession\ObservationRecord.cs` | Immutable per-acknowledgment record (sequence, text, status, timestamp) — append-only |
+| `Services\ReviewSession\ReviewFileEntry.cs` | Mutable per-file state inside a session: status, chunk index/count, cached chunks, observation history, delivery/ack timestamps |
+| `Services\ReviewSession\ReviewSession.cs` | Aggregate. Per-instance lock. Methods `NextItem`, `RecordObservation`, `Submit`. Enforces acknowledgment gate (FR-007/FR-008) and submit gate (FR-009/FR-011). Includes `NextItemResult`, `RecordResult`, `SubmitResult` discriminated result types. **Stateful** — exception to constitution Principle VI scoped to review sessions only |
+| `Services\ReviewSession\IReviewSessionStore.cs` / `ReviewSessionStore.cs` | Singleton in-memory store backed by `ConcurrentDictionary<string, ReviewSession>`. No removal — process lifetime only |
+| `Services\ReviewSession\ISingleFileChunker.cs` / `SingleFileChunker.cs` | Hunk-aware single-file splitter (~80 LOC). Prefers `@@ ... @@` boundaries; pathological hunks split mid-hunk with explicit `MidHunkSplitMarker` |
+| `Tools\BeginPullRequestReviewToolHandler.cs` | `[McpServerTool(Name = "begin_pr_review")]` — resolves budget, awaits enrichment with friendly-status fallback, sorts files alphabetically, creates session, returns manifest |
+| `Tools\NextReviewItemToolHandler.cs` | `[McpServerTool(Name = "next_review_item")]` — delivers next pending file or next chunk, formats response, enforces ack gate via `McpException` |
+| `Tools\RecordReviewObservationToolHandler.cs` | `[McpServerTool(Name = "record_review_observation")]` — appends observation, updates status, returns progress |
+| `Tools\SubmitPullRequestReviewToolHandler.cs` | `[McpServerTool(Name = "submit_pr_review")]` — accepts review or returns structured rejection (NOT exception) listing unacknowledged files; honors `force` override and records it in audit trail |
+| `Tools\Shared\PlainTextFormatter.cs` (extended) | Added `FormatSessionManifest`, `FormatAdvanceResponse`, `FormatObservationConfirmation`, `FormatAcknowledgmentGateError`, `FormatSessionNotFoundError`, `FormatUnacknowledgedFilesError`, `FormatAuditTrail` |
+
+DI registrations (`Program.cs:170-172`): `IReviewSessionStore` and `ISingleFileChunker` as singletons. The four handler classes are auto-discovered by `WithToolsFromAssembly()`.
+
 ---
 
 ## Test files

--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -328,6 +328,36 @@ The orchestrator's load-bearing semantic — caller cancellation never cancels t
 | `get_pr_content(prNumber, pageNumber, [modelName], [maxTokens])` | Returns diff content for a specific page of the PR. Call `get_pr_metadata` with budget params first to discover the total page count |
 | `get_pr_files(prNumber, [pageReference])` | Returns classified list of changed files with per-file stats and review priority; supports pagination via `pageReference` |
 
+#### Stateful PR Review Session (feature 012 — recommended for very large PRs)
+
+For PRs that exceed your agent's context window (especially small-context agents
+like Copilot, GPT-4o-mini, Haiku) the **review session** lets you walk the PR one
+file at a time with server-side acknowledgment tracking. Every file is reviewed;
+nothing is silently skipped.
+
+| Tool | Description |
+|---|---|
+| `begin_pr_review(prNumber, [modelName], [maxTokens])` | Starts a stateful review session. Returns a session id and an alphabetically-sorted manifest of every file in the PR. |
+| `next_review_item(sessionId)` | Returns the next file (or next chunk of an oversize file). Refuses to advance past a fully-delivered file until you call `record_review_observation`. |
+| `record_review_observation(sessionId, filePath, observations, status)` | Records an observation. `status` is `reviewed_complete` or `skipped_with_reason`. Append-only — multiple observations on the same file are preserved. |
+| `submit_pr_review(sessionId, reviewText, [force])` | Finalizes the review. Rejects with a structured error listing unacknowledged files unless `force=true` (which is recorded in the audit trail). |
+
+**Key properties:**
+- Server-enforced acknowledgment gate — no silent abandonment, cherry-picking, or lost-in-the-middle.
+- Every response fits under the configured transport ceiling (default 20k tokens). Oversize single files are split into ordered chunks.
+- Sessions live only in process memory. A server restart discards all in-flight sessions; call `begin_pr_review` again.
+- See `specs/012-review-session-mvp/` for the full spec, plan, and acceptance criteria.
+
+**Workflow:**
+
+```
+begin_pr_review(prNumber)              ← returns sessionId + manifest
+  → loop:
+      next_review_item(sessionId)      ← get next file or chunk
+      record_review_observation(sessionId, filePath, observations, "reviewed_complete")
+  → submit_pr_review(sessionId, reviewText)   ← gets audit trail
+```
+
 ### Local Self-Review Tools (no authentication needed)
 
 | Tool | Description |

--- a/REBUSS.Pure.SmokeTests/McpProtocol/McpServerSmokeTests.cs
+++ b/REBUSS.Pure.SmokeTests/McpProtocol/McpServerSmokeTests.cs
@@ -15,7 +15,11 @@ public class McpServerSmokeTests
         "get_pr_files",
         "get_local_files",
         "get_pr_content",
-        "get_local_content"
+        "get_local_content",
+        "begin_pr_review",
+        "next_review_item",
+        "record_review_observation",
+        "submit_pr_review"
     ];
 
     [Fact]

--- a/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
+++ b/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
@@ -42,14 +42,15 @@ public class ToolsListProtocolTests
     }
 
     [Fact]
-    public async Task ToolsList_ReturnsAllFiveTools()
+    public async Task ToolsList_ReturnsAllNineTools()
     {
         var response = await _fixture.Server.SendToolsListAsync();
         var tools = response.RootElement
             .GetProperty("result")
             .GetProperty("tools");
 
-        Assert.Equal(5, tools.GetArrayLength());
+        // Five legacy PR/local tools + four review-session tools (feature 012).
+        Assert.Equal(9, tools.GetArrayLength());
     }
 
     [Fact]

--- a/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionAggregateTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionAggregateTests.cs
@@ -1,0 +1,226 @@
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Services.ReviewSession;
+using RSession = REBUSS.Pure.Services.ReviewSession.ReviewSession;
+
+namespace REBUSS.Pure.Tests.Services.ReviewSession;
+
+public class ReviewSessionAggregateTests
+{
+    private static (RSession Session, ISingleFileChunker Chunker) NewSession(
+        params (string Path, string Content)[] files)
+    {
+        var entries = files
+            .Select(f => new ReviewFileEntry(f.Path, FileCategory.Source, f.Content.Length))
+            .ToList();
+        var enriched = files.ToDictionary(f => f.Path, f => f.Content);
+
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+
+        var s = new RSession("sid", 42, "head", 10_000, entries, enriched, DateTimeOffset.UtcNow);
+        return (s, chunker);
+    }
+
+    [Fact]
+    public void HappyPath_DeliverThenAck_TransitionsToReviewedComplete()
+    {
+        var (s, ch) = NewSession(("a.cs", "content-a"));
+        var now = DateTimeOffset.UtcNow;
+
+        var r = s.NextItem(ch, now);
+        Assert.Equal(NextItemKind.Delivered, r.Kind);
+        Assert.Equal("a.cs", r.File!.Path);
+        Assert.Equal(ReviewItemStatus.DeliveredAwaitingObservation, r.File.Status);
+
+        var rec = s.RecordObservation("a.cs", "looks good", ReviewItemStatus.ReviewedComplete, now);
+        Assert.Equal(RecordKind.Ok, rec.Kind);
+        Assert.Equal(ReviewItemStatus.ReviewedComplete, s.Files[0].Status);
+        Assert.Equal(1, rec.AcknowledgedCount);
+    }
+
+    [Fact]
+    public void NextItem_BeforeAck_RefusesToAdvance()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"), ("b.cs", "y"));
+        s.NextItem(ch, DateTimeOffset.UtcNow);
+
+        var second = s.NextItem(ch, DateTimeOffset.UtcNow);
+        Assert.Equal(NextItemKind.NeedsAcknowledgment, second.Kind);
+        Assert.Equal("a.cs", second.File!.Path);
+    }
+
+    [Fact]
+    public void RecordObservation_OnPending_Rejected()
+    {
+        var (s, _) = NewSession(("a.cs", "x"));
+        var r = s.RecordObservation("a.cs", "obs", ReviewItemStatus.ReviewedComplete, DateTimeOffset.UtcNow);
+        Assert.Equal(RecordKind.RejectedFileNotDelivered, r.Kind);
+    }
+
+    [Fact]
+    public void AppendOnly_TwoObservationsPreservedWithMonotonicSeq()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "first take", ReviewItemStatus.ReviewedComplete, now);
+        s.RecordObservation("a.cs", "second thought", ReviewItemStatus.ReviewedComplete, now);
+
+        var obs = s.Files[0].Observations;
+        Assert.Equal(2, obs.Count);
+        Assert.Equal(1, obs[0].SequenceNumber);
+        Assert.Equal(2, obs[1].SequenceNumber);
+        Assert.Equal("first take", obs[0].Text);
+        Assert.Equal("second thought", obs[1].Text);
+    }
+
+    [Fact]
+    public void StatusReflectsMostRecentAcknowledgment()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+        s.RecordObservation("a.cs", "actually skip", ReviewItemStatus.SkippedWithReason, now);
+        Assert.Equal(ReviewItemStatus.SkippedWithReason, s.Files[0].Status);
+    }
+
+    [Fact]
+    public void ChunkedFile_DeliveredAcrossMultipleNextItemCalls()
+    {
+        // Force chunking by giving a very small budget via a separate constructor.
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", safeBudgetTokens: 25, entries, enriched, DateTimeOffset.UtcNow);
+
+        var r1 = session.NextItem(chunker, DateTimeOffset.UtcNow);
+        Assert.Equal(NextItemKind.Delivered, r1.Kind);
+        Assert.True(r1.TotalChunks >= 2);
+        Assert.Equal(ReviewItemStatus.DeliveredPartial, session.Files[0].Status);
+
+        // Subsequent calls without ack return next chunk (NOT NeedsAcknowledgment).
+        for (int i = 2; i <= r1.TotalChunks; i++)
+        {
+            var ri = session.NextItem(chunker, DateTimeOffset.UtcNow);
+            Assert.Equal(NextItemKind.Delivered, ri.Kind);
+            Assert.Equal(i, ri.ChunkIndex);
+        }
+        Assert.Equal(ReviewItemStatus.DeliveredAwaitingObservation, session.Files[0].Status);
+
+        // Recording on a partially-delivered file is rejected (mid-chunk).
+        // — verified separately by the partial-test below.
+    }
+
+    [Fact]
+    public void RecordObservation_OnPartial_Rejected()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", safeBudgetTokens: 25, entries, enriched, DateTimeOffset.UtcNow);
+
+        session.NextItem(chunker, DateTimeOffset.UtcNow); // chunk 1, file in DeliveredPartial
+        var rec = session.RecordObservation("big.cs", "premature", ReviewItemStatus.ReviewedComplete, DateTimeOffset.UtcNow);
+        Assert.Equal(RecordKind.RejectedFilePartial, rec.Kind);
+    }
+
+    [Fact]
+    public void Submit_AllAcknowledged_Accepted()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+        var sub = s.Submit("final review", force: false, now);
+        Assert.Equal(SubmitKind.Accepted, sub.Kind);
+        Assert.True(s.IsSubmitted);
+        Assert.Equal("final review", s.FinalReviewText);
+    }
+
+    [Fact]
+    public void Submit_Incomplete_NoForce_Rejected()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"), ("b.cs", "y"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+
+        var sub = s.Submit("review", force: false, now);
+        Assert.Equal(SubmitKind.RejectedIncomplete, sub.Kind);
+        Assert.Single(sub.UnacknowledgedFiles);
+        Assert.Equal("b.cs", sub.UnacknowledgedFiles[0].Path);
+        Assert.False(s.IsSubmitted);
+    }
+
+    [Fact]
+    public void Submit_Incomplete_WithForce_AcceptsAndRecordsOverride()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"), ("b.cs", "y"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+
+        var sub = s.Submit("review", force: true, now);
+        Assert.Equal(SubmitKind.AcceptedWithForce, sub.Kind);
+        Assert.True(s.IsSubmitted);
+        Assert.True(s.SubmissionUsedForce);
+        Assert.Single(sub.UnacknowledgedFiles);
+    }
+
+    [Fact]
+    public void NextItem_AfterSubmit_ReturnsSessionSubmitted()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+        s.Submit("r", false, now);
+
+        var r = s.NextItem(ch, now);
+        Assert.Equal(NextItemKind.SessionSubmitted, r.Kind);
+    }
+
+    [Fact]
+    public void EnrichmentMissing_AutoSkipsAndContinues()
+    {
+        var entries = new List<ReviewFileEntry>
+        {
+            new("missing.cs", FileCategory.Source, 1),
+            new("present.cs", FileCategory.Source, 1),
+        };
+        var enriched = new Dictionary<string, string> { ["present.cs"] = "ok" };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", 1000, entries, enriched, DateTimeOffset.UtcNow);
+
+        var r = session.NextItem(chunker, DateTimeOffset.UtcNow);
+        Assert.Equal(NextItemKind.Delivered, r.Kind);
+        Assert.Equal("present.cs", r.File!.Path);
+        Assert.Equal(ReviewItemStatus.SkippedWithReason, session.Files[0].Status); // missing.cs auto-skipped
+        Assert.Single(session.Files[0].Observations);
+    }
+
+    [Fact]
+    public void Files_AreDeliveredInListOrder()
+    {
+        // Caller is responsible for sorting; aggregate respects the supplied order.
+        var (s, ch) = NewSession(("a.cs", "1"), ("b.cs", "2"), ("c.cs", "3"));
+        var now = DateTimeOffset.UtcNow;
+        var first = s.NextItem(ch, now);
+        Assert.Equal("a.cs", first.File!.Path);
+        s.RecordObservation("a.cs", "x", ReviewItemStatus.ReviewedComplete, now);
+        var second = s.NextItem(ch, now);
+        Assert.Equal("b.cs", second.File!.Path);
+    }
+}

--- a/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionIntegrationTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionIntegrationTests.cs
@@ -1,0 +1,266 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Core.Models.Pagination;
+using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Services.PrEnrichment;
+using REBUSS.Pure.Services.ResponsePacking;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools;
+
+namespace REBUSS.Pure.Tests.Services.ReviewSession;
+
+/// <summary>
+/// End-to-end lifecycle integration covering US1–US5: begin → next/record loop → submit
+/// against a fake metadata provider and a stub enrichment orchestrator.
+/// </summary>
+public class ReviewSessionIntegrationTests
+{
+    private readonly IPullRequestDataProvider _meta = Substitute.For<IPullRequestDataProvider>();
+    private readonly IContextBudgetResolver _budget = Substitute.For<IContextBudgetResolver>();
+    private readonly IPrEnrichmentOrchestrator _orchestrator = Substitute.For<IPrEnrichmentOrchestrator>();
+    private readonly ReviewSessionStore _store = new();
+    private readonly SingleFileChunker _chunker;
+    private readonly IOptions<WorkflowOptions> _workflow =
+        Options.Create(new WorkflowOptions { MetadataInternalTimeoutMs = 5_000, ContentInternalTimeoutMs = 5_000 });
+
+    private readonly BeginPullRequestReviewToolHandler _begin;
+    private readonly NextReviewItemToolHandler _next;
+    private readonly RecordReviewObservationToolHandler _record;
+    private readonly SubmitPullRequestReviewToolHandler _submit;
+
+    public ReviewSessionIntegrationTests()
+    {
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        _chunker = new SingleFileChunker(est);
+
+        _meta.GetMetadataAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(new FullPullRequestMetadata
+            {
+                PullRequestId = 42,
+                Title = "test",
+                Status = "active",
+                LastMergeSourceCommitId = "head-sha",
+                LastMergeTargetCommitId = "base-sha",
+                CommitShas = new List<string> { "head-sha" },
+            });
+
+        _budget.Resolve(Arg.Any<int?>(), Arg.Any<string?>())
+            .Returns(new BudgetResolutionResult(200_000, 10_000, BudgetSource.Default, Array.Empty<string>()));
+
+        _orchestrator.TryGetSnapshot(Arg.Any<int>()).Returns((PrEnrichmentJobSnapshot?)null);
+
+        _begin = new BeginPullRequestReviewToolHandler(
+            _meta, _budget, _orchestrator, _store, _workflow,
+            NullLogger<BeginPullRequestReviewToolHandler>.Instance);
+        _next = new NextReviewItemToolHandler(_store, _chunker,
+            NullLogger<NextReviewItemToolHandler>.Instance);
+        _record = new RecordReviewObservationToolHandler(_store,
+            NullLogger<RecordReviewObservationToolHandler>.Instance);
+        _submit = new SubmitPullRequestReviewToolHandler(_store,
+            NullLogger<SubmitPullRequestReviewToolHandler>.Instance);
+    }
+
+    private void StubEnrichment(int n, int sizeEach = 50)
+    {
+        var candidates = Enumerable.Range(0, n)
+            .Select(i => new PackingCandidate($"src/file_{(char)('a' + i)}.cs", sizeEach, FileCategory.Source, 5))
+            .ToArray();
+        var enriched = candidates.ToDictionary(
+            c => c.Path,
+            c => $"@@ -1,3 +1,3 @@\n+content of {c.Path}\n");
+        var result = new PrEnrichmentResult
+        {
+            PrNumber = 42,
+            HeadSha = "head-sha",
+            SortedCandidates = candidates,
+            EnrichedByPath = enriched,
+            Allocation = new PageAllocation(Array.Empty<PageSlice>(), 0, 0),
+            SafeBudgetTokens = 10_000,
+            CompletedAt = DateTimeOffset.UtcNow,
+        };
+        _orchestrator.WaitForEnrichmentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(result);
+    }
+
+    private static string TextOf(IEnumerable<ContentBlock> blocks) =>
+        string.Concat(blocks.OfType<TextContentBlock>().Select(t => t.Text));
+
+    private static string ExtractSessionId(string manifest)
+    {
+        var idx = manifest.IndexOf("Session id:", StringComparison.Ordinal);
+        var line = manifest.Substring(idx).Split('\n')[0];
+        return line.Split(':')[1].Trim();
+    }
+
+    // ─── US1: Full lifecycle happy path + SC-003 enrichment-once + FR-013 audit replay ──
+
+    [Fact]
+    public async Task FullLifecycle_FiveFiles_AllAcknowledgedAndAuditTrailReplayable()
+    {
+        StubEnrichment(5);
+
+        var manifestBlocks = await _begin.ExecuteAsync(prNumber: 42);
+        var manifest = TextOf(manifestBlocks);
+        var sid = ExtractSessionId(manifest);
+        Assert.Contains("Files:      5", manifest);
+
+        for (int i = 0; i < 5; i++)
+        {
+            var nextBlocks = await _next.ExecuteAsync(sessionId: sid);
+            var nextText = TextOf(nextBlocks);
+            Assert.Contains("===", nextText);
+            // Recover the path from the header
+            var path = nextText.Split('\n')[0].Replace("===", "").Trim();
+            await _record.ExecuteAsync(sessionId: sid, filePath: path,
+                observations: $"observation for {path}", status: "reviewed_complete");
+        }
+
+        var subBlocks = await _submit.ExecuteAsync(sessionId: sid, reviewText: "Overall LGTM");
+        var subText = TextOf(subBlocks);
+        Assert.Contains("Final Review", subText);
+        Assert.Contains("Audit Trail", subText);
+        Assert.Contains("Overall LGTM", subText);
+        for (int i = 0; i < 5; i++)
+            Assert.Contains($"file_{(char)('a' + i)}.cs", subText);
+
+        // SC-003: enrichment triggered exactly once across the whole lifecycle.
+        _orchestrator.Received(1).TriggerEnrichment(42, "head-sha", Arg.Any<int>());
+
+        // FR-013: submitted session is queryable post-submit.
+        Assert.True(_store.TryGet(sid, out var session));
+        Assert.True(session.IsSubmitted);
+        Assert.Equal("Overall LGTM", session.FinalReviewText);
+    }
+
+    // ─── T026a: FR-022 / SC-002 transport size assertion ─────────────────────────────
+
+    [Fact]
+    public async Task FullLifecycle_EveryResponseStaysUnderSafeBudget()
+    {
+        StubEnrichment(3);
+        var manifestBlocks = await _begin.ExecuteAsync(prNumber: 42);
+        var manifest = TextOf(manifestBlocks);
+        var sid = ExtractSessionId(manifest);
+
+        Assert.True(manifest.Length <= 10_000, $"manifest length {manifest.Length} > 10000 budget");
+
+        for (int i = 0; i < 3; i++)
+        {
+            var nextText = TextOf(await _next.ExecuteAsync(sessionId: sid));
+            Assert.True(nextText.Length <= 10_000, $"next response length {nextText.Length} > budget");
+            var path = nextText.Split('\n')[0].Replace("===", "").Trim();
+            var recText = TextOf(await _record.ExecuteAsync(sessionId: sid, filePath: path,
+                observations: "ok", status: "reviewed_complete"));
+            Assert.True(recText.Length <= 10_000);
+        }
+
+        var subText = TextOf(await _submit.ExecuteAsync(sessionId: sid, reviewText: "ok"));
+        Assert.True(subText.Length <= 10_000);
+    }
+
+    // ─── US2: Acknowledgment gate enforcement ──────────────────────────────────────
+
+    [Fact]
+    public async Task AdvancingPastUnacknowledgedFile_RaisesGateError()
+    {
+        StubEnrichment(2);
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+        await _next.ExecuteAsync(sessionId: sid);
+        var ex = await Assert.ThrowsAsync<McpException>(() => _next.ExecuteAsync(sessionId: sid));
+        Assert.Contains("not yet acknowledged", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── US3: Force submission ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submit_WithoutForce_OnIncomplete_ReturnsStructuredRejection()
+    {
+        StubEnrichment(3);
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+        // Acknowledge only one file
+        var nextText = TextOf(await _next.ExecuteAsync(sessionId: sid));
+        var path = nextText.Split('\n')[0].Replace("===", "").Trim();
+        await _record.ExecuteAsync(sessionId: sid, filePath: path,
+            observations: "ok", status: "reviewed_complete");
+
+        var rejText = TextOf(await _submit.ExecuteAsync(sessionId: sid, reviewText: "incomplete"));
+        Assert.Contains("Cannot submit", rejText);
+        Assert.Contains("force=true", rejText);
+        Assert.False(_store.TryGet(sid, out var s) && s.IsSubmitted);
+    }
+
+    [Fact]
+    public async Task Submit_WithForce_OnIncomplete_AcceptsAndAuditTrailRecordsOverride()
+    {
+        StubEnrichment(3);
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+        var nextText = TextOf(await _next.ExecuteAsync(sessionId: sid));
+        var path = nextText.Split('\n')[0].Replace("===", "").Trim();
+        await _record.ExecuteAsync(sessionId: sid, filePath: path,
+            observations: "ok", status: "reviewed_complete");
+
+        var subText = TextOf(await _submit.ExecuteAsync(sessionId: sid, reviewText: "shipping anyway", force: true));
+        Assert.Contains("Audit Trail", subText);
+        Assert.Contains("Override:", subText);
+        Assert.Contains("FORCE", subText);
+    }
+
+    // ─── US4: Append-only observations across the lifecycle ─────────────────────────
+
+    [Fact]
+    public async Task AppendingSecondObservation_OnSameFile_PreservesBothInOrder()
+    {
+        StubEnrichment(2);
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+
+        var nextText = TextOf(await _next.ExecuteAsync(sessionId: sid));
+        var pathA = nextText.Split('\n')[0].Replace("===", "").Trim();
+        await _record.ExecuteAsync(sessionId: sid, filePath: pathA,
+            observations: "first take", status: "reviewed_complete");
+
+        var nextText2 = TextOf(await _next.ExecuteAsync(sessionId: sid));
+        var pathB = nextText2.Split('\n')[0].Replace("===", "").Trim();
+        await _record.ExecuteAsync(sessionId: sid, filePath: pathB,
+            observations: "ok", status: "reviewed_complete");
+
+        // Now go back and add a follow-up to file A.
+        await _record.ExecuteAsync(sessionId: sid, filePath: pathA,
+            observations: "second thought after seeing B", status: "reviewed_complete");
+
+        Assert.True(_store.TryGet(sid, out var session));
+        var fileA = session.Files.First(f => f.Path == pathA);
+        Assert.Equal(2, fileA.Observations.Count);
+        Assert.Equal(1, fileA.Observations[0].SequenceNumber);
+        Assert.Equal(2, fileA.Observations[1].SequenceNumber);
+        Assert.Equal("first take", fileA.Observations[0].Text);
+        Assert.Equal("second thought after seeing B", fileA.Observations[1].Text);
+    }
+
+    // ─── US5: Concurrent independent sessions ──────────────────────────────────────
+
+    [Fact]
+    public async Task TwoSessions_DifferentPRs_DoNotInterfere()
+    {
+        StubEnrichment(2);
+        var sid1 = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+        var sid2 = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 99)));
+        Assert.NotEqual(sid1, sid2);
+        Assert.Equal(2, _store.Count);
+    }
+
+    // ─── Session lookup error path ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task NextReviewItem_OnUnknownSession_ReturnsSessionNotFound()
+    {
+        var blocks = await _next.ExecuteAsync(sessionId: "no-such-session");
+        var text = TextOf(blocks);
+        Assert.Contains("not found", text);
+        Assert.Contains("begin_pr_review", text);
+    }
+}

--- a/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionStoreTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionStoreTests.cs
@@ -1,0 +1,68 @@
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Services.ReviewSession;
+using RSession = REBUSS.Pure.Services.ReviewSession.ReviewSession;
+
+namespace REBUSS.Pure.Tests.Services.ReviewSession;
+
+public class ReviewSessionStoreTests
+{
+    private static RSession NewSession(string id, int prNumber = 1)
+    {
+        var files = new List<ReviewFileEntry>
+        {
+            new("a.cs", FileCategory.Source, 100),
+        };
+        var enriched = new Dictionary<string, string> { ["a.cs"] = "@@ -1,1 +1,1 @@\n+x" };
+        return new RSession(id, prNumber, "head-sha", 1000, files, enriched, DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void Add_TryGet_RoundTrip()
+    {
+        var store = new ReviewSessionStore();
+        var s = NewSession("abc");
+        store.Add(s);
+
+        Assert.True(store.TryGet("abc", out var got));
+        Assert.Same(s, got);
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryGet_MissingId_ReturnsFalse()
+    {
+        var store = new ReviewSessionStore();
+        Assert.False(store.TryGet("nope", out _));
+    }
+
+    [Fact]
+    public void Add_DuplicateId_Throws()
+    {
+        var store = new ReviewSessionStore();
+        store.Add(NewSession("dup"));
+        Assert.Throws<InvalidOperationException>(() => store.Add(NewSession("dup")));
+    }
+
+    [Fact]
+    public async Task Add_Concurrent_DoesNotCollide()
+    {
+        var store = new ReviewSessionStore();
+        var tasks = Enumerable.Range(0, 50)
+            .Select(i => Task.Run(() => store.Add(NewSession("s-" + i, prNumber: i))))
+            .ToArray();
+        await Task.WhenAll(tasks);
+        Assert.Equal(50, store.Count);
+    }
+
+    [Fact]
+    public void SimulatedRestart_FreshStoreInstance_DoesNotSeeOldSessions()
+    {
+        // Lock in FR-018 / SC-007: in-memory state lifetime equals process lifetime.
+        // A "restart" is modelled by instantiating a fresh store; the old id must be unknown.
+        var storeA = new ReviewSessionStore();
+        storeA.Add(NewSession("survives-restart?"));
+
+        var storeB = new ReviewSessionStore();
+        Assert.False(storeB.TryGet("survives-restart?", out _));
+    }
+}

--- a/REBUSS.Pure.Tests/Services/ReviewSession/SingleFileChunkerTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/SingleFileChunkerTests.cs
@@ -1,0 +1,78 @@
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Services.ReviewSession;
+
+namespace REBUSS.Pure.Tests.Services.ReviewSession;
+
+public class SingleFileChunkerTests
+{
+    private static SingleFileChunker NewChunker(int tokensPerChar = 1)
+    {
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length * tokensPerChar);
+        return new SingleFileChunker(est);
+    }
+
+    [Fact]
+    public void Split_SmallFile_ReturnsSingleChunk()
+    {
+        var chunker = NewChunker();
+        var text = "@@ -1,3 +1,3 @@\n line1\n+line2\n line3";
+        var result = chunker.Split(text, budgetTokens: 10_000);
+
+        Assert.Single(result);
+        Assert.Equal(text, result[0]);
+    }
+
+    [Fact]
+    public void Split_TwoHunks_SplitsAtHunkBoundary()
+    {
+        var chunker = NewChunker();
+        var hunk1 = "@@ -1,2 +1,2 @@\n a\n+b\n";
+        var hunk2 = "@@ -10,2 +10,2 @@\n c\n+d";
+        var text = hunk1 + hunk2;
+
+        // Budget that fits one hunk but not both
+        var result = chunker.Split(text, budgetTokens: hunk1.Length + 5);
+
+        Assert.True(result.Count >= 2, $"expected ≥2 chunks, got {result.Count}");
+        Assert.StartsWith("@@ -1,", result[0]);
+        Assert.Contains("@@ -10,", result[1]);
+    }
+
+    [Fact]
+    public void Split_PathologicalHunk_ForcesMidHunkSplitWithMarker()
+    {
+        var chunker = NewChunker();
+        // One huge hunk far exceeding the budget
+        var bigBody = string.Join("\n", Enumerable.Range(0, 50).Select(i => "+line" + i));
+        var text = "@@ -1,50 +1,50 @@\n" + bigBody;
+
+        var result = chunker.Split(text, budgetTokens: 80);
+
+        Assert.True(result.Count >= 2);
+        Assert.Contains(result, c => c.Contains(SingleFileChunker.MidHunkSplitMarker));
+    }
+
+    [Fact]
+    public void Split_RoundTrip_ReproducesContentModuloMarkers()
+    {
+        var chunker = NewChunker();
+        var text = "@@ -1,2 +1,2 @@\n a\n+b\n@@ -10,2 +10,2 @@\n c\n+d";
+        var result = chunker.Split(text, budgetTokens: 30);
+
+        var rejoined = string.Concat(result)
+            .Replace(SingleFileChunker.MidHunkSplitMarker, string.Empty)
+            .Replace("\n\n", "\n");
+        Assert.Contains("a", rejoined);
+        Assert.Contains("d", rejoined);
+        Assert.Contains("@@ -10,", rejoined);
+    }
+
+    [Fact]
+    public void Split_NegativeBudget_Throws()
+    {
+        var chunker = NewChunker();
+        Assert.Throws<ArgumentOutOfRangeException>(() => chunker.Split("text", 0));
+    }
+}

--- a/REBUSS.Pure/Program.cs
+++ b/REBUSS.Pure/Program.cs
@@ -167,6 +167,11 @@ namespace REBUSS.Pure
             services.Configure<WorkflowOptions>(configuration.GetSection(WorkflowOptions.SectionName));
             services.AddSingleton<IPrEnrichmentOrchestrator, PrEnrichmentOrchestrator>();
 
+            // Stateful PR Review Session (feature 012). Singleton store + chunker.
+            // Constitution Principle VI exception scoped to review sessions only.
+            services.AddSingleton<Services.ReviewSession.IReviewSessionStore, Services.ReviewSession.ReviewSessionStore>();
+            services.AddSingleton<Services.ReviewSession.ISingleFileChunker, Services.ReviewSession.SingleFileChunker>();
+
             // Context Window Awareness
             services.Configure<ContextWindowOptions>(configuration.GetSection(ContextWindowOptions.SectionName));
 

--- a/REBUSS.Pure/Services/ReviewSession/IReviewSessionStore.cs
+++ b/REBUSS.Pure/Services/ReviewSession/IReviewSessionStore.cs
@@ -1,0 +1,13 @@
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// In-memory store of active and completed review sessions (FR-018).
+/// Singleton lifetime — sessions are added on <c>begin_pr_review</c> and never
+/// removed except by process exit. State lives only in process memory.
+/// </summary>
+public interface IReviewSessionStore
+{
+    bool TryGet(string sessionId, out ReviewSession session);
+    void Add(ReviewSession session);
+    int Count { get; }
+}

--- a/REBUSS.Pure/Services/ReviewSession/ISingleFileChunker.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ISingleFileChunker.cs
@@ -1,0 +1,13 @@
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Splits a single file's enriched plain-text into ordered self-contained chunks
+/// that fit under a token budget. Prefers <c>@@ ... @@</c> hunk-header boundaries;
+/// pathological hunks larger than the budget are split mid-hunk with an explicit
+/// warning marker (FR-023, FR-024). Round-trip invariant: concatenating the
+/// returned chunks (modulo warning markers) reproduces the input.
+/// </summary>
+public interface ISingleFileChunker
+{
+    IReadOnlyList<string> Split(string enrichedText, int budgetTokens);
+}

--- a/REBUSS.Pure/Services/ReviewSession/ObservationRecord.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ObservationRecord.cs
@@ -1,0 +1,11 @@
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// One immutable entry in a file's append-only observation history (FR-014, FR-015).
+/// Once added to a <see cref="ReviewFileEntry.Observations"/> list, never modified.
+/// </summary>
+public sealed record ObservationRecord(
+    int SequenceNumber,
+    string Text,
+    ReviewItemStatus Status,
+    DateTimeOffset RecordedAt);

--- a/REBUSS.Pure/Services/ReviewSession/ReviewFileEntry.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ReviewFileEntry.cs
@@ -1,0 +1,39 @@
+using REBUSS.Pure.Core.Models;
+
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Per-file state within a <see cref="ReviewSession"/>. Mutated only under the
+/// parent session's lock. See data-model.md for invariants.
+/// </summary>
+public sealed class ReviewFileEntry
+{
+    public ReviewFileEntry(string path, FileCategory category, int estimatedTokens)
+    {
+        Path = path;
+        Category = category;
+        EstimatedTokens = estimatedTokens;
+        Status = ReviewItemStatus.Pending;
+        Observations = new List<ObservationRecord>();
+    }
+
+    public string Path { get; }
+    public FileCategory Category { get; }
+    public int EstimatedTokens { get; }
+
+    public ReviewItemStatus Status { get; internal set; }
+
+    /// <summary>1-based index of the most recently delivered chunk; null until any delivery.</summary>
+    public int? CurrentChunkIndex { get; internal set; }
+
+    /// <summary>Total chunk count for this file; null for files that fit in one response.</summary>
+    public int? TotalChunks { get; internal set; }
+
+    /// <summary>Lazily computed by <see cref="ReviewSession"/> on first oversize delivery; cached for the session lifetime.</summary>
+    public IReadOnlyList<string>? Chunks { get; internal set; }
+
+    public List<ObservationRecord> Observations { get; }
+
+    public DateTimeOffset? DeliveredAt { get; internal set; }
+    public DateTimeOffset? LastAcknowledgedAt { get; internal set; }
+}

--- a/REBUSS.Pure/Services/ReviewSession/ReviewItemStatus.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ReviewItemStatus.cs
@@ -1,0 +1,23 @@
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Lifecycle states for a single file within a stateful PR review session.
+/// See <c>specs/012-review-session-mvp/data-model.md</c> for the full state machine.
+/// </summary>
+public enum ReviewItemStatus
+{
+    /// <summary>Not yet delivered to the agent.</summary>
+    Pending,
+
+    /// <summary>One or more chunks of the file have been delivered, but not the final chunk.</summary>
+    DeliveredPartial,
+
+    /// <summary>The whole file (or its final chunk) has been delivered. The acknowledgment gate is engaged.</summary>
+    DeliveredAwaitingObservation,
+
+    /// <summary>The agent has acknowledged the file as fully reviewed.</summary>
+    ReviewedComplete,
+
+    /// <summary>The agent has acknowledged the file as deliberately skipped (with a reason).</summary>
+    SkippedWithReason,
+}

--- a/REBUSS.Pure/Services/ReviewSession/ReviewSession.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ReviewSession.cs
@@ -1,0 +1,248 @@
+using REBUSS.Pure.Core.Models;
+
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Stateful per-PR review session aggregate. All mutation goes through methods
+/// on this class and is serialized by an internal lock. The state machine
+/// (Pending → DeliveredPartial → DeliveredAwaitingObservation → ReviewedComplete |
+/// SkippedWithReason) is enforced here so that all four MCP tool handlers see
+/// identical semantics.
+///
+/// This is the load-bearing exception to constitution Principle VI documented in
+/// FR-030 of the feature spec.
+/// </summary>
+public sealed class ReviewSession
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, ReviewFileEntry> _byPath;
+    private readonly IReadOnlyDictionary<string, string> _enrichedByPath;
+
+    public ReviewSession(
+        string sessionId,
+        int prNumber,
+        string headSha,
+        int safeBudgetTokens,
+        IReadOnlyList<ReviewFileEntry> files,
+        IReadOnlyDictionary<string, string> enrichedByPath,
+        DateTimeOffset createdAt)
+    {
+        SessionId = sessionId;
+        PrNumber = prNumber;
+        HeadSha = headSha;
+        SafeBudgetTokens = safeBudgetTokens;
+        Files = files;
+        _enrichedByPath = enrichedByPath;
+        CreatedAt = createdAt;
+        _byPath = files.ToDictionary(f => f.Path, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public string SessionId { get; }
+    public int PrNumber { get; }
+    public string HeadSha { get; }
+    public DateTimeOffset CreatedAt { get; }
+    public int SafeBudgetTokens { get; }
+    public IReadOnlyList<ReviewFileEntry> Files { get; }
+    public bool IsSubmitted { get; private set; }
+    public DateTimeOffset? SubmittedAt { get; private set; }
+    public bool SubmissionUsedForce { get; private set; }
+    public string? FinalReviewText { get; private set; }
+
+    public int AcknowledgedCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return Files.Count(f =>
+                    f.Status == ReviewItemStatus.ReviewedComplete ||
+                    f.Status == ReviewItemStatus.SkippedWithReason);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the next item to deliver: the next chunk of a partially-delivered
+    /// file, OR the next pending file (whole or first chunk).
+    /// Enforces FR-007 (acknowledgment gate) and FR-012 (post-submit lockout).
+    /// </summary>
+    public NextItemResult NextItem(ISingleFileChunker chunker, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(chunker);
+        lock (_lock)
+        {
+            if (IsSubmitted)
+                return new NextItemResult(NextItemKind.SessionSubmitted, null, null, 0, 0);
+
+            // 1. If any file is in DeliveredPartial → return its next chunk.
+            var partial = Files.FirstOrDefault(f => f.Status == ReviewItemStatus.DeliveredPartial);
+            if (partial is not null)
+                return DeliverNextChunk(partial, now);
+
+            // 2. Acknowledgment gate: if any file is in DeliveredAwaitingObservation, refuse to advance.
+            var awaiting = Files.FirstOrDefault(f => f.Status == ReviewItemStatus.DeliveredAwaitingObservation);
+            if (awaiting is not null)
+                return new NextItemResult(NextItemKind.NeedsAcknowledgment, awaiting, null, 0, 0);
+
+            // 3. Find the next Pending file in alphabetical order (Files is pre-sorted).
+            var next = Files.FirstOrDefault(f => f.Status == ReviewItemStatus.Pending);
+            if (next is null)
+                return new NextItemResult(NextItemKind.AllDelivered, null, null, 0, 0);
+
+            // Defensive: if enrichment did not produce content for this path, auto-skip with reason.
+            if (!_enrichedByPath.TryGetValue(next.Path, out var enriched) || enriched is null)
+            {
+                next.Status = ReviewItemStatus.SkippedWithReason;
+                next.DeliveredAt = now;
+                next.LastAcknowledgedAt = now;
+                next.Observations.Add(new ObservationRecord(
+                    SequenceNumber: 1,
+                    Text: "auto-skipped: enrichment unavailable for this file",
+                    Status: ReviewItemStatus.SkippedWithReason,
+                    RecordedAt: now));
+                // Recurse via tail-call style: try the next file.
+                return NextItem(chunker, now);
+            }
+
+            // 4. If the file fits the budget, deliver it whole.
+            var chunks = chunker.Split(enriched, SafeBudgetTokens);
+            next.DeliveredAt = now;
+            if (chunks.Count == 1)
+            {
+                next.Status = ReviewItemStatus.DeliveredAwaitingObservation;
+                next.CurrentChunkIndex = 1;
+                next.TotalChunks = 1;
+                return new NextItemResult(NextItemKind.Delivered, next, chunks[0], 1, 1);
+            }
+
+            // 5. Oversize: cache chunks, return chunk 1, mark partial.
+            next.Chunks = chunks;
+            next.TotalChunks = chunks.Count;
+            next.CurrentChunkIndex = 1;
+            next.Status = ReviewItemStatus.DeliveredPartial;
+            return new NextItemResult(NextItemKind.Delivered, next, chunks[0], 1, chunks.Count);
+        }
+    }
+
+    private NextItemResult DeliverNextChunk(ReviewFileEntry partial, DateTimeOffset now)
+    {
+        var nextIdx = (partial.CurrentChunkIndex ?? 0) + 1;
+        var total = partial.TotalChunks ?? partial.Chunks!.Count;
+        partial.CurrentChunkIndex = nextIdx;
+        var content = partial.Chunks![nextIdx - 1];
+        if (nextIdx >= total)
+            partial.Status = ReviewItemStatus.DeliveredAwaitingObservation;
+        return new NextItemResult(NextItemKind.Delivered, partial, content, nextIdx, total);
+    }
+
+    /// <summary>
+    /// Records an observation against a previously-delivered file. Append-only —
+    /// existing observations are never modified (FR-014, FR-015, FR-016).
+    /// </summary>
+    public RecordResult RecordObservation(string filePath, string observations, ReviewItemStatus declaredStatus, DateTimeOffset now)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(filePath);
+        ArgumentNullException.ThrowIfNull(observations);
+
+        if (declaredStatus is not (ReviewItemStatus.ReviewedComplete or ReviewItemStatus.SkippedWithReason))
+            return new RecordResult(RecordKind.InvalidStatus, null, 0, 0);
+
+        lock (_lock)
+        {
+            if (IsSubmitted)
+                return new RecordResult(RecordKind.SessionSubmitted, null, 0, 0);
+
+            if (!_byPath.TryGetValue(filePath, out var file))
+                return new RecordResult(RecordKind.FileNotFound, null, 0, 0);
+
+            if (file.Status == ReviewItemStatus.Pending)
+                return new RecordResult(RecordKind.RejectedFileNotDelivered, file, 0, 0);
+
+            if (file.Status == ReviewItemStatus.DeliveredPartial)
+                return new RecordResult(RecordKind.RejectedFilePartial, file, 0, 0);
+
+            var seq = file.Observations.Count == 0 ? 1 : file.Observations[^1].SequenceNumber + 1;
+            file.Observations.Add(new ObservationRecord(seq, observations, declaredStatus, now));
+            file.Status = declaredStatus;
+            file.LastAcknowledgedAt = now;
+
+            int ack = Files.Count(f =>
+                f.Status == ReviewItemStatus.ReviewedComplete ||
+                f.Status == ReviewItemStatus.SkippedWithReason);
+            return new RecordResult(RecordKind.Ok, file, ack, Files.Count);
+        }
+    }
+
+    /// <summary>
+    /// Submits the session. Rejects with a structured result (NOT an exception)
+    /// listing unacknowledged files unless <paramref name="force"/> is true (FR-009/FR-010/FR-011).
+    /// </summary>
+    public SubmitResult Submit(string reviewText, bool force, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(reviewText);
+        lock (_lock)
+        {
+            if (IsSubmitted)
+                return new SubmitResult(SubmitKind.AlreadySubmitted, Array.Empty<ReviewFileEntry>());
+
+            var unacked = Files
+                .Where(f => f.Status != ReviewItemStatus.ReviewedComplete && f.Status != ReviewItemStatus.SkippedWithReason)
+                .ToArray();
+
+            if (unacked.Length > 0 && !force)
+                return new SubmitResult(SubmitKind.RejectedIncomplete, unacked);
+
+            IsSubmitted = true;
+            SubmittedAt = now;
+            SubmissionUsedForce = force && unacked.Length > 0;
+            FinalReviewText = reviewText;
+
+            return new SubmitResult(
+                unacked.Length > 0 ? SubmitKind.AcceptedWithForce : SubmitKind.Accepted,
+                unacked);
+        }
+    }
+}
+
+public enum NextItemKind
+{
+    Delivered,
+    NeedsAcknowledgment,
+    AllDelivered,
+    SessionSubmitted,
+}
+
+public sealed record NextItemResult(
+    NextItemKind Kind,
+    ReviewFileEntry? File,
+    string? Content,
+    int ChunkIndex,
+    int TotalChunks);
+
+public enum RecordKind
+{
+    Ok,
+    FileNotFound,
+    RejectedFileNotDelivered,
+    RejectedFilePartial,
+    InvalidStatus,
+    SessionSubmitted,
+}
+
+public sealed record RecordResult(
+    RecordKind Kind,
+    ReviewFileEntry? File,
+    int AcknowledgedCount,
+    int TotalCount);
+
+public enum SubmitKind
+{
+    Accepted,
+    AcceptedWithForce,
+    RejectedIncomplete,
+    AlreadySubmitted,
+}
+
+public sealed record SubmitResult(
+    SubmitKind Kind,
+    IReadOnlyList<ReviewFileEntry> UnacknowledgedFiles);

--- a/REBUSS.Pure/Services/ReviewSession/ReviewSessionStore.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ReviewSessionStore.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Singleton in-memory store backed by <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+/// This is the load-bearing exception to constitution Principle VI documented in
+/// <c>specs/012-review-session-mvp/spec.md</c> FR-030.
+/// </summary>
+internal sealed class ReviewSessionStore : IReviewSessionStore
+{
+    private readonly ConcurrentDictionary<string, ReviewSession> _sessions = new(StringComparer.Ordinal);
+
+    public bool TryGet(string sessionId, out ReviewSession session)
+    {
+        if (sessionId is null)
+        {
+            session = null!;
+            return false;
+        }
+        return _sessions.TryGetValue(sessionId, out session!);
+    }
+
+    public void Add(ReviewSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (!_sessions.TryAdd(session.SessionId, session))
+            throw new InvalidOperationException($"Session id '{session.SessionId}' already exists in store.");
+    }
+
+    public int Count => _sessions.Count;
+}

--- a/REBUSS.Pure/Services/ReviewSession/SingleFileChunker.cs
+++ b/REBUSS.Pure/Services/ReviewSession/SingleFileChunker.cs
@@ -1,0 +1,78 @@
+using REBUSS.Pure.Core;
+
+namespace REBUSS.Pure.Services.ReviewSession;
+
+/// <summary>
+/// Hunk-aware single-file chunker. NOT a reuse of <c>PageAllocator</c> — that
+/// component is a multi-file bin-packer. See research.md for the rationale.
+/// </summary>
+internal sealed class SingleFileChunker : ISingleFileChunker
+{
+    public const string MidHunkSplitMarker = "[truncated mid-hunk: continued in next chunk]";
+
+    private readonly ITokenEstimator _tokenEstimator;
+
+    public SingleFileChunker(ITokenEstimator tokenEstimator)
+    {
+        _tokenEstimator = tokenEstimator;
+    }
+
+    public IReadOnlyList<string> Split(string enrichedText, int budgetTokens)
+    {
+        ArgumentNullException.ThrowIfNull(enrichedText);
+        if (budgetTokens <= 0)
+            throw new ArgumentOutOfRangeException(nameof(budgetTokens));
+
+        // Fast path: whole file fits.
+        if (_tokenEstimator.EstimateTokenCount(enrichedText) <= budgetTokens)
+            return new[] { enrichedText };
+
+        // Walk lines, accumulating into a current chunk. Prefer to break right
+        // before a "@@ " hunk header so each chunk is a set of complete hunks.
+        var lines = enrichedText.Split('\n');
+        var chunks = new List<string>();
+        var current = new System.Text.StringBuilder();
+        int currentTokens = 0;
+
+        void Flush()
+        {
+            if (current.Length > 0)
+            {
+                chunks.Add(current.ToString().TrimEnd('\n'));
+                current.Clear();
+                currentTokens = 0;
+            }
+        }
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var lineWithNl = line + (i < lines.Length - 1 ? "\n" : string.Empty);
+            var lineTokens = _tokenEstimator.EstimateTokenCount(lineWithNl);
+
+            bool isHunkHeader = line.StartsWith("@@ ", StringComparison.Ordinal);
+
+            // Prefer to flush at a hunk boundary if we already have content and
+            // adding this hunk header would exceed the budget OR we're already past it.
+            if (isHunkHeader && current.Length > 0 && currentTokens + lineTokens > budgetTokens)
+            {
+                Flush();
+            }
+
+            // Pathological case: a single line (or accumulated single hunk) exceeds the budget.
+            if (currentTokens + lineTokens > budgetTokens && current.Length > 0)
+            {
+                // Mid-hunk forced split with explicit warning marker.
+                current.AppendLine();
+                current.Append(MidHunkSplitMarker);
+                Flush();
+            }
+
+            current.Append(lineWithNl);
+            currentTokens += lineTokens;
+        }
+
+        Flush();
+        return chunks;
+    }
+}

--- a/REBUSS.Pure/Tools/BeginPullRequestReviewToolHandler.cs
+++ b/REBUSS.Pure/Tools/BeginPullRequestReviewToolHandler.cs
@@ -1,0 +1,138 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Exceptions;
+using REBUSS.Pure.Services.PrEnrichment;
+using REBUSS.Pure.Services.ResponsePacking;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+using RSession = REBUSS.Pure.Services.ReviewSession.ReviewSession;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Begins a stateful review session for a PR. See spec 012 FR-001 / FR-005 / FR-020 / FR-021.
+/// </summary>
+[McpServerToolType]
+public class BeginPullRequestReviewToolHandler
+{
+    private readonly IPullRequestDataProvider _metadataProvider;
+    private readonly IContextBudgetResolver _budgetResolver;
+    private readonly IPrEnrichmentOrchestrator _enrichmentOrchestrator;
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly IOptions<WorkflowOptions> _workflowOptions;
+    private readonly ILogger<BeginPullRequestReviewToolHandler> _logger;
+
+    public BeginPullRequestReviewToolHandler(
+        IPullRequestDataProvider metadataProvider,
+        IContextBudgetResolver budgetResolver,
+        IPrEnrichmentOrchestrator enrichmentOrchestrator,
+        IReviewSessionStore sessionStore,
+        IOptions<WorkflowOptions> workflowOptions,
+        ILogger<BeginPullRequestReviewToolHandler> logger)
+    {
+        _metadataProvider = metadataProvider;
+        _budgetResolver = budgetResolver;
+        _enrichmentOrchestrator = enrichmentOrchestrator;
+        _sessionStore = sessionStore;
+        _workflowOptions = workflowOptions;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "begin_pr_review"), Description(
+        "Begins a stateful per-PR review session. Returns a session id and a manifest of every file " +
+        "to review (alphabetically ordered). Subsequent calls go to next_review_item, " +
+        "record_review_observation, and submit_pr_review. Sessions live only in process memory " +
+        "and are lost on server restart.")]
+    public async Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("The Pull Request number/ID")] int? prNumber = null,
+        [Description("Model name for context budget resolution")] string? modelName = null,
+        [Description("Explicit token budget override")] int? maxTokens = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (prNumber == null)
+            throw new McpException("prNumber is required.");
+        if (prNumber <= 0)
+            throw new McpException("prNumber must be a positive integer.");
+
+        try
+        {
+            _logger.LogInformation("begin_pr_review entry: pr={Pr}", prNumber);
+            var budget = _budgetResolver.Resolve(maxTokens, modelName);
+            var safeBudget = budget.SafeBudgetTokens;
+
+            var snapshot = _enrichmentOrchestrator.TryGetSnapshot(prNumber.Value);
+            string headSha;
+            if (snapshot is null)
+            {
+                var meta = await _metadataProvider.GetMetadataAsync(prNumber.Value, cancellationToken);
+                headSha = meta.LastMergeSourceCommitId ?? string.Empty;
+                _enrichmentOrchestrator.TriggerEnrichment(prNumber.Value, headSha, safeBudget);
+            }
+            else
+            {
+                headSha = snapshot.HeadSha ?? string.Empty;
+                if (snapshot.Status != PrEnrichmentStatus.Ready)
+                    _enrichmentOrchestrator.TriggerEnrichment(prNumber.Value, headSha, safeBudget);
+            }
+
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            linkedCts.CancelAfter(_workflowOptions.Value.MetadataInternalTimeoutMs);
+
+            PrEnrichmentResult result;
+            try
+            {
+                result = await _enrichmentOrchestrator.WaitForEnrichmentAsync(prNumber.Value, linkedCts.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("begin_pr_review: enrichment not ready within timeout for pr {Pr}", prNumber);
+                return new[]
+                {
+                    new TextContentBlock
+                    {
+                        Text = PlainTextFormatter.FormatFriendlyStatus(
+                            headline: "PR enrichment still preparing",
+                            explanation: $"Background enrichment for PR #{prNumber} has not completed yet.",
+                            suggestedNextAction: "Call begin_pr_review again in a moment.")
+                    }
+                };
+            }
+
+            // Sort alphabetically by Path (FR-005). Reuse PackingCandidate fields.
+            var files = result.SortedCandidates
+                .OrderBy(c => c.Path, StringComparer.OrdinalIgnoreCase)
+                .Select(c => new ReviewFileEntry(c.Path, c.Category, c.EstimatedTokens))
+                .ToList();
+
+            var sessionId = Guid.NewGuid().ToString("N");
+            var session = new RSession(
+                sessionId,
+                prNumber.Value,
+                result.HeadSha,
+                safeBudget,
+                files,
+                result.EnrichedByPath,
+                DateTimeOffset.UtcNow);
+            _sessionStore.Add(session);
+
+            var manifest = PlainTextFormatter.FormatSessionManifest(sessionId, prNumber.Value, safeBudget, files);
+            _logger.LogInformation("begin_pr_review: session {Sid} created with {N} files", sessionId, files.Count);
+            return new[] { new TextContentBlock { Text = manifest } };
+        }
+        catch (PullRequestNotFoundException ex)
+        {
+            throw new McpException($"Pull request not found: {ex.Message}");
+        }
+        catch (McpException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "begin_pr_review error for pr {Pr}", prNumber);
+            throw new McpException($"Error beginning review session: {ex.Message}");
+        }
+    }
+}

--- a/REBUSS.Pure/Tools/NextReviewItemToolHandler.cs
+++ b/REBUSS.Pure/Tools/NextReviewItemToolHandler.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Returns the next file (or next chunk of an oversize file) in a review session.
+/// Enforces the acknowledgment gate (FR-007/FR-008) and post-submit lockout (FR-012).
+/// </summary>
+[McpServerToolType]
+public class NextReviewItemToolHandler
+{
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly ISingleFileChunker _chunker;
+    private readonly ILogger<NextReviewItemToolHandler> _logger;
+
+    public NextReviewItemToolHandler(
+        IReviewSessionStore sessionStore,
+        ISingleFileChunker chunker,
+        ILogger<NextReviewItemToolHandler> logger)
+    {
+        _sessionStore = sessionStore;
+        _chunker = chunker;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "next_review_item"), Description(
+        "Returns the next file in the review session — or the next chunk of a file that is " +
+        "too large for one response. Enforces the acknowledgment gate: you cannot advance past " +
+        "a fully-delivered file until you have called record_review_observation for it.")]
+    public Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("The review session id returned by begin_pr_review")] string? sessionId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new McpException("sessionId is required.");
+
+        if (!_sessionStore.TryGet(sessionId, out var session))
+        {
+            return Text(PlainTextFormatter.FormatSessionNotFoundError(sessionId));
+        }
+
+        var result = session.NextItem(_chunker, DateTimeOffset.UtcNow);
+        switch (result.Kind)
+        {
+            case NextItemKind.SessionSubmitted:
+                throw new McpException($"Review session {sessionId} has already been submitted. Call begin_pr_review for a fresh review.");
+            case NextItemKind.AllDelivered:
+                throw new McpException($"All files in review session {sessionId} have been delivered. Call submit_pr_review to finalize.");
+            case NextItemKind.NeedsAcknowledgment:
+                throw new McpException(PlainTextFormatter.FormatAcknowledgmentGateError(result.File!.Path, sessionId));
+            case NextItemKind.Delivered:
+                var totalFiles = session.Files.Count;
+                var position = session.Files.ToList().IndexOf(result.File!) + 1;
+                var remaining = session.Files.Count(f =>
+                    f.Status is ReviewItemStatus.Pending or ReviewItemStatus.DeliveredPartial or ReviewItemStatus.DeliveredAwaitingObservation);
+                var text = PlainTextFormatter.FormatAdvanceResponse(
+                    result.File!,
+                    result.Content!,
+                    result.ChunkIndex,
+                    result.TotalChunks,
+                    position,
+                    totalFiles,
+                    remaining,
+                    sessionId);
+                _logger.LogInformation("next_review_item: session {Sid} delivered {Path} chunk {C}/{T}",
+                    sessionId, result.File!.Path, result.ChunkIndex, result.TotalChunks);
+                return Text(text);
+        }
+        throw new McpException("Unknown next-item state.");
+    }
+
+    private static Task<IEnumerable<ContentBlock>> Text(string s) =>
+        Task.FromResult<IEnumerable<ContentBlock>>(new[] { new TextContentBlock { Text = s } });
+}

--- a/REBUSS.Pure/Tools/RecordReviewObservationToolHandler.cs
+++ b/REBUSS.Pure/Tools/RecordReviewObservationToolHandler.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Records an observation against a delivered file. Append-only — multiple
+/// observations on the same file are preserved (FR-014/FR-015/FR-016).
+/// </summary>
+[McpServerToolType]
+public class RecordReviewObservationToolHandler
+{
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly ILogger<RecordReviewObservationToolHandler> _logger;
+
+    public RecordReviewObservationToolHandler(
+        IReviewSessionStore sessionStore,
+        ILogger<RecordReviewObservationToolHandler> logger)
+    {
+        _sessionStore = sessionStore;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "record_review_observation"), Description(
+        "Records the agent's observation against a previously-delivered file in a review session. " +
+        "status must be 'reviewed_complete' or 'skipped_with_reason'. Observations are append-only: " +
+        "you can record multiple observations against the same file and the history is preserved.")]
+    public Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("Review session id from begin_pr_review")] string? sessionId = null,
+        [Description("Path of the file the observation is for")] string? filePath = null,
+        [Description("Free-form observation text")] string? observations = null,
+        [Description("'reviewed_complete' or 'skipped_with_reason'")] string? status = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new McpException("sessionId is required.");
+        if (string.IsNullOrEmpty(filePath))
+            throw new McpException("filePath is required.");
+        if (observations is null)
+            throw new McpException("observations is required.");
+        if (string.IsNullOrEmpty(status))
+            throw new McpException("status is required ('reviewed_complete' or 'skipped_with_reason').");
+
+        var declared = status switch
+        {
+            "reviewed_complete" => ReviewItemStatus.ReviewedComplete,
+            "skipped_with_reason" => ReviewItemStatus.SkippedWithReason,
+            _ => throw new McpException("status must be 'reviewed_complete' or 'skipped_with_reason'."),
+        };
+
+        if (!_sessionStore.TryGet(sessionId, out var session))
+            return Text(PlainTextFormatter.FormatSessionNotFoundError(sessionId));
+
+        var result = session.RecordObservation(filePath, observations, declared, DateTimeOffset.UtcNow);
+        switch (result.Kind)
+        {
+            case RecordKind.Ok:
+                var text = PlainTextFormatter.FormatObservationConfirmation(
+                    filePath, result.AcknowledgedCount, result.TotalCount, sessionId);
+                _logger.LogInformation("record_review_observation: session {Sid} {Path} -> {Status}",
+                    sessionId, filePath, declared);
+                return Text(text);
+            case RecordKind.SessionSubmitted:
+                throw new McpException($"Review session {sessionId} has already been submitted.");
+            case RecordKind.FileNotFound:
+                throw new McpException($"File '{filePath}' is not part of review session {sessionId}.");
+            case RecordKind.RejectedFileNotDelivered:
+                throw new McpException($"File '{filePath}' has not been delivered yet. Call next_review_item first.");
+            case RecordKind.RejectedFilePartial:
+                throw new McpException($"File '{filePath}' is only partially delivered. Call next_review_item until the final chunk is received before recording an observation.");
+            case RecordKind.InvalidStatus:
+                throw new McpException("Invalid status declared.");
+        }
+        throw new McpException("Unknown record-observation state.");
+    }
+
+    private static Task<IEnumerable<ContentBlock>> Text(string s) =>
+        Task.FromResult<IEnumerable<ContentBlock>>(new[] { new TextContentBlock { Text = s } });
+}

--- a/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
+++ b/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
@@ -276,6 +276,139 @@ internal static class PlainTextFormatter
 
     // ─── Manifest block ───────────────────────────────────────────────────────────
 
+    // ─── Review session (feature 012) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Formats the manifest returned by <c>begin_pr_review</c>. Truncates the file
+    /// list with an "... and N more" marker if it would exceed <paramref name="maxFilesShown"/>.
+    /// </summary>
+    public static string FormatSessionManifest(
+        string sessionId,
+        int prNumber,
+        int safeBudgetTokens,
+        IReadOnlyList<Services.ReviewSession.ReviewFileEntry> files,
+        int maxFilesShown = 200)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Review session ready");
+        sb.AppendLine($"Session id: {sessionId}");
+        sb.AppendLine($"PR:         #{prNumber}");
+        sb.AppendLine($"Files:      {files.Count}");
+        sb.AppendLine($"Budget:     {safeBudgetTokens} tokens per response");
+        sb.AppendLine($"Estimated:  ~{files.Sum(f => f.EstimatedTokens)} tokens total");
+        sb.AppendLine();
+        sb.AppendLine("Files to review (alphabetical):");
+        var shown = Math.Min(files.Count, maxFilesShown);
+        for (int i = 0; i < shown; i++)
+        {
+            var f = files[i];
+            sb.AppendLine($"  {i + 1,4}. {f.Path}  [{f.Category}, ~{f.EstimatedTokens} tokens]");
+        }
+        if (files.Count > shown)
+            sb.AppendLine($"  ... and {files.Count - shown} more (walk via next_review_item)");
+        sb.AppendLine();
+        sb.Append($"Next: call next_review_item with sessionId={sessionId}");
+        return sb.ToString();
+    }
+
+    public static string FormatAdvanceResponse(
+        Services.ReviewSession.ReviewFileEntry file,
+        string content,
+        int chunkIndex,
+        int totalChunks,
+        int filePosition,
+        int totalFiles,
+        int filesRemaining,
+        string sessionId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"=== {file.Path} ===");
+        var chunkInfo = totalChunks > 1 ? $", chunk {chunkIndex} of {totalChunks}" : string.Empty;
+        sb.AppendLine($"File {filePosition} of {totalFiles}{chunkInfo} | {filesRemaining} file(s) remaining");
+        sb.AppendLine();
+        sb.AppendLine(content);
+        sb.AppendLine();
+        if (totalChunks > 1 && chunkIndex < totalChunks)
+            sb.Append($"--- More chunks of this file remain. Call next_review_item with sessionId={sessionId} to receive chunk {chunkIndex + 1} of {totalChunks}.");
+        else
+            sb.Append($"--- After reviewing this file, call record_review_observation with sessionId={sessionId}, filePath=\"{file.Path}\", and your observations before requesting the next item.");
+        return sb.ToString();
+    }
+
+    public static string FormatObservationConfirmation(
+        string filePath,
+        int acknowledgedCount,
+        int totalCount,
+        string sessionId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Observation recorded for {filePath}.");
+        sb.AppendLine($"Progress: {acknowledgedCount} of {totalCount} files acknowledged.");
+        sb.Append(acknowledgedCount < totalCount
+            ? $"Next: call next_review_item with sessionId={sessionId}"
+            : $"Next: call submit_pr_review with sessionId={sessionId} to finalize the review.");
+        return sb.ToString();
+    }
+
+    public static string FormatAcknowledgmentGateError(string filePath, string sessionId)
+    {
+        return $"Cannot advance: file '{filePath}' has been delivered but not yet acknowledged. " +
+               $"Call record_review_observation with sessionId={sessionId}, filePath=\"{filePath}\" " +
+               $"before requesting the next item.";
+    }
+
+    public static string FormatSessionNotFoundError(string sessionId)
+    {
+        return $"Review session '{sessionId}' was not found. " +
+               "Sessions are in-memory and do not persist across server restarts. " +
+               "Call begin_pr_review to start a fresh session.";
+    }
+
+    public static string FormatUnacknowledgedFilesError(
+        string sessionId,
+        IReadOnlyList<Services.ReviewSession.ReviewFileEntry> unacknowledged)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Cannot submit: the following files have not been acknowledged:");
+        foreach (var f in unacknowledged)
+            sb.AppendLine($"  - {f.Path}  [state: {f.Status}]");
+        sb.AppendLine();
+        sb.AppendLine("Either:");
+        sb.AppendLine($"  1. Call next_review_item with sessionId={sessionId} to walk through them, then record observations; or");
+        sb.AppendLine($"  2. Re-call submit_pr_review with force=true to override (the override will be recorded in the audit trail).");
+        return sb.ToString().TrimEnd();
+    }
+
+    public static string FormatAuditTrail(
+        Services.ReviewSession.ReviewSession session,
+        string reviewText)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("=== Final Review ===");
+        sb.AppendLine(reviewText);
+        sb.AppendLine();
+        sb.AppendLine("=== Audit Trail ===");
+        sb.AppendLine($"Session id: {session.SessionId}");
+        sb.AppendLine($"PR:         #{session.PrNumber}");
+        sb.AppendLine($"Head SHA:   {session.HeadSha}");
+        sb.AppendLine($"Created:    {session.CreatedAt:O}");
+        sb.AppendLine($"Submitted:  {session.SubmittedAt:O}");
+        if (session.SubmissionUsedForce)
+            sb.AppendLine("Override:   FORCE — submission accepted with unacknowledged files");
+        sb.AppendLine();
+        sb.AppendLine($"Files ({session.Files.Count}):");
+        for (int i = 0; i < session.Files.Count; i++)
+        {
+            var f = session.Files[i];
+            var lastObs = f.Observations.Count > 0 ? f.Observations[^1].Text : "(no observation)";
+            var truncated = lastObs.Length > 120 ? lastObs[..117] + "..." : lastObs;
+            sb.AppendLine($"  {i + 1,4}. [{f.Status}] {f.Path}");
+            sb.AppendLine($"        delivered: {f.DeliveredAt:O} | acknowledged: {f.LastAcknowledgedAt:O}");
+            sb.AppendLine($"        last observation: {truncated}");
+        }
+        return sb.ToString().TrimEnd();
+    }
+
     public static string FormatManifestBlock(
         ContentManifestResult manifest,
         string? pageContext = null)

--- a/REBUSS.Pure/Tools/SubmitPullRequestReviewToolHandler.cs
+++ b/REBUSS.Pure/Tools/SubmitPullRequestReviewToolHandler.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Submits a completed review. Rejects with a structured tool result (NOT an
+/// exception) listing unacknowledged files unless force=true (FR-009/FR-010/FR-011).
+/// </summary>
+[McpServerToolType]
+public class SubmitPullRequestReviewToolHandler
+{
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly ILogger<SubmitPullRequestReviewToolHandler> _logger;
+
+    public SubmitPullRequestReviewToolHandler(
+        IReviewSessionStore sessionStore,
+        ILogger<SubmitPullRequestReviewToolHandler> logger)
+    {
+        _sessionStore = sessionStore;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "submit_pr_review"), Description(
+        "Submits the final review for a session. Rejects (with a structured error result) " +
+        "if any file is unacknowledged, unless force=true. The audit trail records every file's " +
+        "final status, delivery order, timestamps, and any forced override.")]
+    public Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("Review session id from begin_pr_review")] string? sessionId = null,
+        [Description("The final review text")] string? reviewText = null,
+        [Description("Force-accept submission even if files are unacknowledged (records override in audit trail)")] bool force = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new McpException("sessionId is required.");
+        if (reviewText is null)
+            throw new McpException("reviewText is required.");
+
+        if (!_sessionStore.TryGet(sessionId, out var session))
+            return Text(PlainTextFormatter.FormatSessionNotFoundError(sessionId));
+
+        var result = session.Submit(reviewText, force, DateTimeOffset.UtcNow);
+        switch (result.Kind)
+        {
+            case SubmitKind.Accepted:
+            case SubmitKind.AcceptedWithForce:
+                var audit = PlainTextFormatter.FormatAuditTrail(session, reviewText);
+                _logger.LogInformation("submit_pr_review: session {Sid} accepted (force={Force})",
+                    sessionId, session.SubmissionUsedForce);
+                return Text(audit);
+            case SubmitKind.RejectedIncomplete:
+                // Returned as a structured tool result, NOT an exception (FR-010).
+                return Text(PlainTextFormatter.FormatUnacknowledgedFilesError(sessionId, result.UnacknowledgedFiles));
+            case SubmitKind.AlreadySubmitted:
+                throw new McpException($"Review session {sessionId} has already been submitted.");
+        }
+        throw new McpException("Unknown submit state.");
+    }
+
+    private static Task<IEnumerable<ContentBlock>> Text(string s) =>
+        Task.FromResult<IEnumerable<ContentBlock>>(new[] { new TextContentBlock { Text = s } });
+}


### PR DESCRIPTION
Four new MCP tools (begin_pr_review, next_review_item, record_review_observation, submit_pr_review) backed by an in-memory IReviewSessionStore so small-context agents can review arbitrarily large PRs file-by-file with a server-enforced acknowledgment gate. Oversize single files split via a dedicated hunk-aware SingleFileChunker. Submission rejects unacknowledged files unless force=true (audited).