### PR TITLE
Add review memory: refetch + query (feature 013)

### DIFF
--- a/.github/CodebaseUnderstanding.md
+++ b/.github/CodebaseUnderstanding.md
@@ -463,6 +463,17 @@ Note: As of the plain-text ContentBlock refactor, most JSON output DTOs have bee
 
 DI registrations (`Program.cs:170-172`): `IReviewSessionStore` and `ISingleFileChunker` as singletons. The four handler classes are auto-discovered by `WithToolsFromAssembly()`.
 
+#### Review Memory — feature 013 (additive on top of 012)
+
+| File | Role |
+|---|---|
+| `Services\ReviewSession\ReviewSession.cs` (extended) | Two new pure-read methods: `Refetch(filePath, chunkIndex)` and `QueryObservations(query, limit)`, plus `RefetchKind`/`RefetchResult`/`QueryKind`/`QueryResultEntry`/`QueryResult` records. Both methods run under the existing per-session lock and never write to any field. Constants: `MaxQueryLimit = 20`, `MaxObservationCharsInResult = 2000` |
+| `Tools\RefetchReviewItemToolHandler.cs` | `[McpServerTool(Name = "refetch_review_item")]` — re-reads acknowledged file content; respects the gate (rejects `Pending`/`DeliveredPartial`); supports chunked refetch; allowed against submitted sessions |
+| `Tools\QueryReviewNotesToolHandler.cs` | `[McpServerTool(Name = "query_review_notes")]` — free-text search over recorded observations; whitespace-tokenized case-insensitive substring scoring; default limit 5, max 20 |
+| `Tools\Shared\PlainTextFormatter.cs` (extended) | Added `FormatRefetchResponse`, `FormatQueryResponse`, `FormatNoMatchesResponse` |
+
+No new DI registrations — both handlers auto-discovered. No new singletons. The constitution Principle VI exception scoped to `IReviewSessionStore` (added in feature 012) covers this feature without widening.
+
 ---
 
 ## Test files

--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -341,6 +341,8 @@ nothing is silently skipped.
 | `next_review_item(sessionId)` | Returns the next file (or next chunk of an oversize file). Refuses to advance past a fully-delivered file until you call `record_review_observation`. |
 | `record_review_observation(sessionId, filePath, observations, status)` | Records an observation. `status` is `reviewed_complete` or `skipped_with_reason`. Append-only — multiple observations on the same file are preserved. |
 | `submit_pr_review(sessionId, reviewText, [force])` | Finalizes the review. Rejects with a structured error listing unacknowledged files unless `force=true` (which is recorded in the audit trail). |
+| `refetch_review_item(sessionId, filePath, [chunkIndex])` | (feature 013) Re-reads any acknowledged file's exact original content. Pure read; never re-runs enrichment. Use mid-review to verify a cross-reference or recall a forgotten detail. Honors the acknowledgment gate — rejects files in `Pending` or partial-delivery state. |
+| `query_review_notes(sessionId, query, [limit])` | (feature 013) Free-text searches your own previously-recorded observations across the session. Use before `submit_pr_review` to compose a final review from accumulated observations. Default limit 5, max 20. |
 
 **Key properties:**
 - Server-enforced acknowledgment gate — no silent abandonment, cherry-picking, or lost-in-the-middle.

--- a/REBUSS.Pure.SmokeTests/McpProtocol/McpServerSmokeTests.cs
+++ b/REBUSS.Pure.SmokeTests/McpProtocol/McpServerSmokeTests.cs
@@ -19,7 +19,9 @@ public class McpServerSmokeTests
         "begin_pr_review",
         "next_review_item",
         "record_review_observation",
-        "submit_pr_review"
+        "submit_pr_review",
+        "refetch_review_item",
+        "query_review_notes"
     ];
 
     [Fact]

--- a/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
+++ b/REBUSS.Pure.SmokeTests/Protocol/ToolsListProtocolTests.cs
@@ -42,15 +42,15 @@ public class ToolsListProtocolTests
     }
 
     [Fact]
-    public async Task ToolsList_ReturnsAllNineTools()
+    public async Task ToolsList_ReturnsAllElevenTools()
     {
         var response = await _fixture.Server.SendToolsListAsync();
         var tools = response.RootElement
             .GetProperty("result")
             .GetProperty("tools");
 
-        // Five legacy PR/local tools + four review-session tools (feature 012).
-        Assert.Equal(9, tools.GetArrayLength());
+        // Five legacy + four review-session (012) + two review-memory (013) tools.
+        Assert.Equal(11, tools.GetArrayLength());
     }
 
     [Fact]

--- a/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionAggregateTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionAggregateTests.cs
@@ -211,6 +211,307 @@ public class ReviewSessionAggregateTests
         Assert.Single(session.Files[0].Observations);
     }
 
+    // ─── Feature 013: Refetch ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Refetch_OnPending_ReturnsFilePending()
+    {
+        var (s, _) = NewSession(("a.cs", "content"));
+        var r = s.Refetch("a.cs", 1);
+        Assert.Equal(RefetchKind.FilePending, r.Kind);
+    }
+
+    [Fact]
+    public void Refetch_OnPartial_ReturnsFilePartial()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", safeBudgetTokens: 25, entries, enriched, DateTimeOffset.UtcNow);
+        session.NextItem(chunker, DateTimeOffset.UtcNow); // file goes into DeliveredPartial
+
+        var r = session.Refetch("big.cs", 1);
+        Assert.Equal(RefetchKind.FilePartial, r.Kind);
+    }
+
+    [Fact]
+    public void Refetch_OnReviewedComplete_ReturnsExactOriginalContent()
+    {
+        var (s, ch) = NewSession(("a.cs", "exact-content"));
+        var now = DateTimeOffset.UtcNow;
+        var deliv = s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+
+        var r = s.Refetch("a.cs", 1);
+        Assert.Equal(RefetchKind.Ok, r.Kind);
+        Assert.Equal(deliv.Content, r.Content);
+        Assert.Equal(1, r.ChunkIndex);
+        Assert.Equal(1, r.TotalChunks);
+    }
+
+    [Fact]
+    public void Refetch_OnSubmittedSession_StillSucceeds()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+        s.Submit("done", false, now);
+
+        var r = s.Refetch("a.cs", 1);
+        Assert.Equal(RefetchKind.Ok, r.Kind);
+        Assert.Equal("x", r.Content);
+    }
+
+    [Fact]
+    public void Refetch_OnFileNotInSession_ReturnsFileNotInSession()
+    {
+        var (s, _) = NewSession(("a.cs", "x"));
+        var r = s.Refetch("zzz.cs", 1);
+        Assert.Equal(RefetchKind.FileNotInSession, r.Kind);
+    }
+
+    [Fact]
+    public void Refetch_OnChunkedFile_DefaultIndex1_ReturnsChunk1()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", 25, entries, enriched, DateTimeOffset.UtcNow);
+        // Walk all chunks to reach DeliveredAwaitingObservation
+        var first = session.NextItem(chunker, DateTimeOffset.UtcNow);
+        var total = first.TotalChunks;
+        for (int i = 2; i <= total; i++) session.NextItem(chunker, DateTimeOffset.UtcNow);
+
+        var r = session.Refetch("big.cs", 1);
+        Assert.Equal(RefetchKind.Ok, r.Kind);
+        Assert.Equal(1, r.ChunkIndex);
+        Assert.Equal(total, r.TotalChunks);
+    }
+
+    [Fact]
+    public void Refetch_OnChunkedFile_Index2_ReturnsChunk2()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", 25, entries, enriched, DateTimeOffset.UtcNow);
+        var first = session.NextItem(chunker, DateTimeOffset.UtcNow);
+        var total = first.TotalChunks;
+        Assert.True(total >= 2, "test setup must produce at least 2 chunks");
+        for (int i = 2; i <= total; i++) session.NextItem(chunker, DateTimeOffset.UtcNow);
+
+        var r = session.Refetch("big.cs", 2);
+        Assert.Equal(RefetchKind.Ok, r.Kind);
+        Assert.Equal(2, r.ChunkIndex);
+    }
+
+    [Fact]
+    public void Refetch_ChunkIndexOutOfRange_ReturnsChunkOutOfRange()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", 25, entries, enriched, DateTimeOffset.UtcNow);
+        var first = session.NextItem(chunker, DateTimeOffset.UtcNow);
+        var total = first.TotalChunks;
+        for (int i = 2; i <= total; i++) session.NextItem(chunker, DateTimeOffset.UtcNow);
+
+        Assert.Equal(RefetchKind.ChunkOutOfRange, session.Refetch("big.cs", 0).Kind);
+        Assert.Equal(RefetchKind.ChunkOutOfRange, session.Refetch("big.cs", total + 1).Kind);
+    }
+
+    [Fact]
+    public void Refetch_OnUnchunkedFile_NonOneIndex_ReturnsChunkOutOfRange()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "ok", ReviewItemStatus.ReviewedComplete, now);
+
+        Assert.Equal(RefetchKind.ChunkOutOfRange, s.Refetch("a.cs", 2).Kind);
+        Assert.Equal(RefetchKind.ChunkOutOfRange, s.Refetch("a.cs", 0).Kind);
+    }
+
+    [Fact]
+    public void Refetch_DoesNotMutateSessionState()
+    {
+        var (s, ch) = NewSession(("a.cs", "x"), ("b.cs", "y"));
+        var now = DateTimeOffset.UtcNow;
+        s.NextItem(ch, now);
+        s.RecordObservation("a.cs", "first", ReviewItemStatus.ReviewedComplete, now);
+
+        var beforeStatuses = s.Files.Select(f => f.Status).ToArray();
+        var beforeObsCounts = s.Files.Select(f => f.Observations.Count).ToArray();
+        var beforeAck = s.AcknowledgedCount;
+
+        // Multiple refetches
+        s.Refetch("a.cs", 1);
+        s.Refetch("a.cs", 1);
+        s.Refetch("zzz.cs", 1);
+
+        Assert.Equal(beforeStatuses, s.Files.Select(f => f.Status).ToArray());
+        Assert.Equal(beforeObsCounts, s.Files.Select(f => f.Observations.Count).ToArray());
+        Assert.Equal(beforeAck, s.AcknowledgedCount);
+    }
+
+    // ─── Feature 013: Query ───────────────────────────────────────────────────────
+
+    private static RSession SessionWithObservations(params (string Path, string ObsText, ReviewItemStatus Status)[] obs)
+    {
+        var paths = obs.Select(o => o.Path).Distinct().ToArray();
+        var entries = paths.Select(p => new ReviewFileEntry(p, FileCategory.Source, 1)).ToList();
+        var enriched = paths.ToDictionary(p => p, p => "content-" + p);
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var session = new RSession("s", 1, "h", 10_000, entries, enriched, DateTimeOffset.UtcNow);
+        var now = DateTimeOffset.UtcNow;
+        // Deliver each file then record the observation
+        var deliveredPaths = new HashSet<string>();
+        foreach (var (path, text, status) in obs)
+        {
+            if (!deliveredPaths.Contains(path))
+            {
+                // Walk to that file
+                while (true)
+                {
+                    var r = session.NextItem(chunker, now);
+                    if (r.Kind == NextItemKind.Delivered && r.File!.Path == path) break;
+                    if (r.Kind == NextItemKind.Delivered)
+                        session.RecordObservation(r.File!.Path, "filler", ReviewItemStatus.ReviewedComplete, now);
+                }
+                deliveredPaths.Add(path);
+            }
+            session.RecordObservation(path, text, status, now);
+        }
+        return session;
+    }
+
+    [Fact]
+    public void Query_EmptyString_ReturnsEmptyQuery()
+    {
+        var s = SessionWithObservations(("a.cs", "obs", ReviewItemStatus.ReviewedComplete));
+        Assert.Equal(QueryKind.EmptyQuery, s.QueryObservations("", 5).Kind);
+        Assert.Equal(QueryKind.EmptyQuery, s.QueryObservations("   ", 5).Kind);
+        Assert.Equal(QueryKind.EmptyQuery, s.QueryObservations(null, 5).Kind);
+    }
+
+    [Fact]
+    public void Query_NoMatches_ReturnsOkWithEmptyEntries()
+    {
+        var s = SessionWithObservations(("a.cs", "completely unrelated", ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("validation", 5);
+        Assert.Equal(QueryKind.Ok, r.Kind);
+        Assert.Empty(r.Entries);
+    }
+
+    [Fact]
+    public void Query_SimpleSubstringMatch()
+    {
+        var s = SessionWithObservations(
+            ("a.cs", "validation now requires CancellationToken", ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("validation", 5);
+        Assert.Single(r.Entries);
+        Assert.Contains("validation", r.Entries[0].Text);
+    }
+
+    [Fact]
+    public void Query_CaseInsensitive()
+    {
+        var s = SessionWithObservations(
+            ("a.cs", "Validation now requires Token", ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("VALIDATION", 5);
+        Assert.Single(r.Entries);
+    }
+
+    [Fact]
+    public void Query_MultiToken_ScoredByDistinctTokenCount()
+    {
+        var s = SessionWithObservations(
+            ("a.cs", "validation null inputs handled", ReviewItemStatus.ReviewedComplete),
+            ("b.cs", "validation only", ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("validation null", 5);
+        Assert.Equal(2, r.Entries.Count);
+        Assert.Equal("a.cs", r.Entries[0].FilePath); // higher score (2 tokens)
+        Assert.Equal(2, r.Entries[0].MatchScore);
+        Assert.Equal(1, r.Entries[1].MatchScore);
+    }
+
+    [Fact]
+    public void Query_TieBreakAlphabeticalByFilePath()
+    {
+        var s = SessionWithObservations(
+            ("zeta.cs", "match", ReviewItemStatus.ReviewedComplete),
+            ("alpha.cs", "match", ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("match", 5);
+        Assert.Equal("alpha.cs", r.Entries[0].FilePath);
+        Assert.Equal("zeta.cs", r.Entries[1].FilePath);
+    }
+
+    [Fact]
+    public void Query_TruncatesObservationOver2000Chars_AndSetsIsTruncated()
+    {
+        var longObs = "validation " + new string('x', 5000);
+        var s = SessionWithObservations(("a.cs", longObs, ReviewItemStatus.ReviewedComplete));
+        var r = s.QueryObservations("validation", 5);
+        Assert.Single(r.Entries);
+        Assert.True(r.Entries[0].IsTruncated);
+        Assert.Equal(RSession.MaxObservationCharsInResult, r.Entries[0].Text.Length);
+    }
+
+    [Fact]
+    public void Query_LimitDefault5_AndCappedAt20()
+    {
+        var observations = Enumerable.Range(0, 30)
+            .Select(i => ($"f{i:D3}.cs", "match here", ReviewItemStatus.ReviewedComplete))
+            .ToArray();
+        var s = SessionWithObservations(observations);
+        var r = s.QueryObservations("match", 100);
+        Assert.Equal(20, r.Entries.Count);
+        Assert.Equal(30, r.TotalMatches);
+    }
+
+    [Fact]
+    public void Query_DoesNotMutateSessionState()
+    {
+        var s = SessionWithObservations(
+            ("a.cs", "validation matches", ReviewItemStatus.ReviewedComplete),
+            ("b.cs", "skipped due to validation noise", ReviewItemStatus.SkippedWithReason));
+
+        var beforeStatuses = s.Files.Select(f => f.Status).ToArray();
+        var beforeObsCounts = s.Files.Select(f => f.Observations.Count).ToArray();
+
+        s.QueryObservations("validation", 5);
+        s.QueryObservations("anything", 20);
+        s.QueryObservations("nomatch", 1);
+
+        Assert.Equal(beforeStatuses, s.Files.Select(f => f.Status).ToArray());
+        Assert.Equal(beforeObsCounts, s.Files.Select(f => f.Observations.Count).ToArray());
+    }
+
+    [Fact]
+    public void Query_IncludesObservationsFromSkippedFiles()
+    {
+        var s = SessionWithObservations(
+            ("a.cs", "skipped: generated file", ReviewItemStatus.SkippedWithReason));
+        var r = s.QueryObservations("generated", 5);
+        Assert.Single(r.Entries);
+        Assert.Equal(ReviewItemStatus.SkippedWithReason, r.Entries[0].Status);
+    }
+
     [Fact]
     public void Files_AreDeliveredInListOrder()
     {

--- a/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionIntegrationTests.cs
+++ b/REBUSS.Pure.Tests/Services/ReviewSession/ReviewSessionIntegrationTests.cs
@@ -255,6 +255,98 @@ public class ReviewSessionIntegrationTests
 
     // ─── Session lookup error path ─────────────────────────────────────────────────
 
+    // ─── Feature 013: Refetch + Query interleaved with the lifecycle ──────────────
+
+    [Fact]
+    public async Task InterleavedRefetchAndQuery_DoNotMutateState_AndContentByteEqualToOriginal()
+    {
+        StubEnrichment(5);
+        var refetch = new RefetchReviewItemToolHandler(_store, NullLogger<RefetchReviewItemToolHandler>.Instance);
+        var query = new QueryReviewNotesToolHandler(_store, NullLogger<QueryReviewNotesToolHandler>.Instance);
+
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+        var originalContentByPath = new Dictionary<string, string>();
+
+        // Walk all 5 files, capturing original content keyed by path.
+        for (int i = 0; i < 5; i++)
+        {
+            var nextText = TextOf(await _next.ExecuteAsync(sessionId: sid));
+            var path = nextText.Split('\n')[0].Replace("===", "").Trim();
+            originalContentByPath[path] = nextText;
+
+            // Intercalate refetches and queries — they MUST be no-ops state-wise.
+            if (i > 0)
+            {
+                var earlierPath = originalContentByPath.Keys.First();
+                var refetchText = TextOf(await refetch.ExecuteAsync(sessionId: sid, filePath: earlierPath));
+                Assert.Contains("[REFETCH]", refetchText);
+
+                // Byte-equality of underlying content (the file body, ignoring the refetch marker prefix and headers).
+                // Verify the actual content body appears in both.
+                var originalBody = originalContentByPath[earlierPath];
+                Assert.Contains("content of " + earlierPath, refetchText);
+                Assert.Contains("content of " + earlierPath, originalBody);
+            }
+
+            await _record.ExecuteAsync(sessionId: sid, filePath: path,
+                observations: $"observation containing keyword-{i} for {path}",
+                status: "reviewed_complete");
+
+            // Query mid-walk — must not change anything.
+            var qText = TextOf(await query.ExecuteAsync(sessionId: sid, query: $"keyword-{i}"));
+            Assert.Contains("keyword-" + i, qText);
+        }
+
+        // Final query before submit
+        var finalQuery = TextOf(await query.ExecuteAsync(sessionId: sid, query: "keyword-2"));
+        Assert.Contains("keyword-2", finalQuery);
+
+        // Submit. Audit trail must NOT mention refetch/query operations (FR-025).
+        var subText = TextOf(await _submit.ExecuteAsync(sessionId: sid, reviewText: "summary"));
+        Assert.Contains("Audit Trail", subText);
+        Assert.DoesNotContain("[REFETCH]", subText);
+        Assert.DoesNotContain("Query:", subText);
+
+        // SC-002: enrichment triggered exactly once across the lifecycle + interleaved reads.
+        _orchestrator.Received(1).TriggerEnrichment(42, "head-sha", Arg.Any<int>());
+
+        // FR-013 / SC-011: refetch still works on the submitted session.
+        var postSubmitText = TextOf(await refetch.ExecuteAsync(
+            sessionId: sid, filePath: originalContentByPath.Keys.First()));
+        Assert.Contains("[REFETCH]", postSubmitText);
+    }
+
+    [Fact]
+    public async Task OperationsUnderStress_NoExtraEnrichmentTriggers()
+    {
+        StubEnrichment(3);
+        var refetch = new RefetchReviewItemToolHandler(_store, NullLogger<RefetchReviewItemToolHandler>.Instance);
+        var query = new QueryReviewNotesToolHandler(_store, NullLogger<QueryReviewNotesToolHandler>.Instance);
+
+        var sid = ExtractSessionId(TextOf(await _begin.ExecuteAsync(prNumber: 42)));
+
+        // Walk + acknowledge all
+        var paths = new List<string>();
+        for (int i = 0; i < 3; i++)
+        {
+            var t = TextOf(await _next.ExecuteAsync(sessionId: sid));
+            var path = t.Split('\n')[0].Replace("===", "").Trim();
+            paths.Add(path);
+            await _record.ExecuteAsync(sessionId: sid, filePath: path,
+                observations: "match-token here", status: "reviewed_complete");
+        }
+
+        // Stress: 20 refetches + 20 queries in mixed order
+        for (int i = 0; i < 20; i++)
+        {
+            await refetch.ExecuteAsync(sessionId: sid, filePath: paths[i % paths.Count]);
+            await query.ExecuteAsync(sessionId: sid, query: "match-token");
+        }
+
+        // Still exactly one enrichment trigger
+        _orchestrator.Received(1).TriggerEnrichment(42, "head-sha", Arg.Any<int>());
+    }
+
     [Fact]
     public async Task NextReviewItem_OnUnknownSession_ReturnsSessionNotFound()
     {

--- a/REBUSS.Pure.Tests/Tools/QueryReviewNotesToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/QueryReviewNotesToolHandlerTests.cs
@@ -1,0 +1,142 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools;
+using RSession = REBUSS.Pure.Services.ReviewSession.ReviewSession;
+
+namespace REBUSS.Pure.Tests.Tools;
+
+public class QueryReviewNotesToolHandlerTests
+{
+    private readonly ReviewSessionStore _store = new();
+    private readonly QueryReviewNotesToolHandler _handler;
+
+    public QueryReviewNotesToolHandlerTests()
+    {
+        _handler = new QueryReviewNotesToolHandler(_store, NullLogger<QueryReviewNotesToolHandler>.Instance);
+    }
+
+    private RSession SeedSessionWithObservations(params (string Path, string Obs)[] obs)
+    {
+        var paths = obs.Select(o => o.Path).Distinct().ToArray();
+        var entries = paths.Select(p => new ReviewFileEntry(p, FileCategory.Source, 1)).ToList();
+        var enriched = paths.ToDictionary(p => p, p => "content");
+        var s = new RSession(Guid.NewGuid().ToString("N"), 1, "head", 10_000, entries, enriched, DateTimeOffset.UtcNow);
+        _store.Add(s);
+
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var now = DateTimeOffset.UtcNow;
+
+        // Walk all files in input order (which matches Files list order); record real
+        // observation immediately so the next iteration's NextItem can advance through the gate.
+        var firstObsByPath = obs.GroupBy(o => o.Path).ToDictionary(g => g.Key, g => g.First().Obs);
+        foreach (var path in paths)
+        {
+            var r = s.NextItem(chunker, now);
+            // r should be Delivered with path == current target (Files are in input order)
+            s.RecordObservation(path, firstObsByPath[path], ReviewItemStatus.ReviewedComplete, now);
+        }
+        return s;
+    }
+
+    private static string TextOf(IEnumerable<ContentBlock> blocks) =>
+        string.Concat(blocks.OfType<TextContentBlock>().Select(t => t.Text));
+
+    [Fact]
+    public async Task HappyPath_ReturnsMatches()
+    {
+        var s = SeedSessionWithObservations(("a.cs", "validation now requires CancellationToken"));
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, query: "validation");
+        var text = TextOf(blocks);
+        Assert.Contains("1 match(es)", text);
+        Assert.Contains("a.cs", text);
+        Assert.Contains("validation", text);
+    }
+
+    [Fact]
+    public async Task MissingSessionId_Throws()
+    {
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: null, query: "x"));
+    }
+
+    [Fact]
+    public async Task MissingQuery_Throws()
+    {
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: "x", query: null));
+    }
+
+    [Fact]
+    public async Task EmptyQuery_Throws()
+    {
+        var s = SeedSessionWithObservations(("a.cs", "x"));
+        var ex = await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, query: ""));
+        Assert.Contains("non-whitespace", ex.Message);
+    }
+
+    [Fact]
+    public async Task WhitespaceOnlyQuery_Throws()
+    {
+        var s = SeedSessionWithObservations(("a.cs", "x"));
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, query: "   "));
+    }
+
+    [Fact]
+    public async Task ZeroMatches_ReturnsNoMatchesText_NotException()
+    {
+        var s = SeedSessionWithObservations(("a.cs", "completely unrelated"));
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, query: "validation");
+        Assert.Contains("No observations match", TextOf(blocks));
+    }
+
+    [Fact]
+    public async Task UnknownSessionId_ReturnsSessionNotFoundText()
+    {
+        var blocks = await _handler.ExecuteAsync(sessionId: "missing", query: "x");
+        Assert.Contains("not found", TextOf(blocks));
+    }
+
+    [Fact]
+    public async Task LimitExceedingMax_CappedAt20()
+    {
+        var obs = Enumerable.Range(0, 30)
+            .Select(i => ($"f{i:D3}.cs", "match here"))
+            .ToArray();
+        var s = SeedSessionWithObservations(obs);
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, query: "match", limit: 100);
+        var text = TextOf(blocks);
+        Assert.Contains("30 match(es) total", text);
+        Assert.Contains("showing top 20", text);
+    }
+
+    [Fact]
+    public async Task TruncationMarkerPresentForLongObservation()
+    {
+        var s = SeedSessionWithObservations(("a.cs", "validation " + new string('x', 5000)));
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, query: "validation");
+        var text = TextOf(blocks);
+        Assert.Contains("truncated", text);
+    }
+
+    [Fact]
+    public async Task MultiToken_OrderedByDescendingScoreThenAlphabetical()
+    {
+        var s = SeedSessionWithObservations(
+            ("zeta.cs", "validation here"),
+            ("alpha.cs", "validation null inputs"),
+            ("beta.cs", "validation here"));
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, query: "validation null");
+        var text = TextOf(blocks);
+        // alpha.cs should appear first (score 2)
+        var alphaIdx = text.IndexOf("alpha.cs");
+        var betaIdx = text.IndexOf("beta.cs");
+        var zetaIdx = text.IndexOf("zeta.cs");
+        Assert.True(alphaIdx > 0 && alphaIdx < betaIdx && alphaIdx < zetaIdx);
+        Assert.True(betaIdx < zetaIdx); // alphabetical tie-break among score-1 entries
+    }
+}

--- a/REBUSS.Pure.Tests/Tools/RefetchReviewItemToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/RefetchReviewItemToolHandlerTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.Core.Models;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools;
+using RSession = REBUSS.Pure.Services.ReviewSession.ReviewSession;
+
+namespace REBUSS.Pure.Tests.Tools;
+
+public class RefetchReviewItemToolHandlerTests
+{
+    private readonly ReviewSessionStore _store = new();
+    private readonly RefetchReviewItemToolHandler _handler;
+
+    public RefetchReviewItemToolHandlerTests()
+    {
+        _handler = new RefetchReviewItemToolHandler(_store, NullLogger<RefetchReviewItemToolHandler>.Instance);
+    }
+
+    private RSession SeedSession(string path = "a.cs", string content = "the-content", bool acknowledge = true)
+    {
+        var entries = new List<ReviewFileEntry> { new(path, FileCategory.Source, content.Length) };
+        var enriched = new Dictionary<string, string> { [path] = content };
+        var s = new RSession(Guid.NewGuid().ToString("N"), 1, "head", 10_000, entries, enriched, DateTimeOffset.UtcNow);
+        _store.Add(s);
+        if (acknowledge)
+        {
+            var est = Substitute.For<ITokenEstimator>();
+            est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+            var chunker = new SingleFileChunker(est);
+            s.NextItem(chunker, DateTimeOffset.UtcNow);
+            s.RecordObservation(path, "ok", ReviewItemStatus.ReviewedComplete, DateTimeOffset.UtcNow);
+        }
+        return s;
+    }
+
+    private static string TextOf(IEnumerable<ContentBlock> blocks) =>
+        string.Concat(blocks.OfType<TextContentBlock>().Select(t => t.Text));
+
+    [Fact]
+    public async Task HappyPath_Acknowledged_ReturnsRefetchMarkerAndContent()
+    {
+        var s = SeedSession();
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "a.cs");
+        var text = TextOf(blocks);
+        Assert.Contains("[REFETCH]", text);
+        Assert.Contains("the-content", text);
+    }
+
+    [Fact]
+    public async Task MissingSessionId_Throws()
+    {
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: null, filePath: "a.cs"));
+    }
+
+    [Fact]
+    public async Task MissingFilePath_Throws()
+    {
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: "x", filePath: null));
+    }
+
+    [Fact]
+    public async Task UnknownSessionId_ReturnsSessionNotFoundText()
+    {
+        var blocks = await _handler.ExecuteAsync(sessionId: "no-such-session", filePath: "a.cs");
+        Assert.Contains("not found", TextOf(blocks));
+    }
+
+    [Fact]
+    public async Task RefetchOnPending_ThrowsWithGateGuidance()
+    {
+        var s = SeedSession(acknowledge: false);
+        var ex = await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "a.cs"));
+        Assert.Contains("next_review_item", ex.Message);
+    }
+
+    [Fact]
+    public async Task RefetchOnPartial_Throws()
+    {
+        // Build a session whose only file is oversized → DeliveredPartial after 1 NextItem call
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var s = new RSession(Guid.NewGuid().ToString("N"), 1, "head", 25, entries, enriched, DateTimeOffset.UtcNow);
+        _store.Add(s);
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        s.NextItem(chunker, DateTimeOffset.UtcNow); // file is now DeliveredPartial
+
+        var ex = await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "big.cs"));
+        Assert.Contains("chunk-by-chunk", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RefetchOnChunkedFile_Index2_ReturnsChunk2WithContinuationHint()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var s = new RSession(Guid.NewGuid().ToString("N"), 1, "head", 25, entries, enriched, DateTimeOffset.UtcNow);
+        _store.Add(s);
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var first = s.NextItem(chunker, DateTimeOffset.UtcNow);
+        var total = first.TotalChunks;
+        for (int i = 2; i <= total; i++) s.NextItem(chunker, DateTimeOffset.UtcNow);
+
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "big.cs", chunkIndex: 2);
+        var text = TextOf(blocks);
+        Assert.Contains("Chunk 2 of", text);
+        if (total > 2)
+            Assert.Contains("More chunks remain", text);
+    }
+
+    [Fact]
+    public async Task RefetchOnChunkedFile_LastChunk_NoContinuationHint()
+    {
+        var entries = new List<ReviewFileEntry> { new("big.cs", FileCategory.Source, 1) };
+        var content = "@@ -1,2 +1,2 @@\nline-a\n@@ -10,2 +10,2 @@\nline-b\n@@ -20,2 +20,2 @@\nline-c";
+        var enriched = new Dictionary<string, string> { ["big.cs"] = content };
+        var s = new RSession(Guid.NewGuid().ToString("N"), 1, "head", 25, entries, enriched, DateTimeOffset.UtcNow);
+        _store.Add(s);
+        var est = Substitute.For<ITokenEstimator>();
+        est.EstimateTokenCount(Arg.Any<string>()).Returns(ci => ((string)ci[0]).Length);
+        var chunker = new SingleFileChunker(est);
+        var first = s.NextItem(chunker, DateTimeOffset.UtcNow);
+        var total = first.TotalChunks;
+        for (int i = 2; i <= total; i++) s.NextItem(chunker, DateTimeOffset.UtcNow);
+
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "big.cs", chunkIndex: total);
+        var text = TextOf(blocks);
+        Assert.Contains("End of refetched content", text);
+        Assert.DoesNotContain("More chunks remain", text);
+    }
+
+    [Fact]
+    public async Task RefetchUnchunkedFile_NonOneIndex_Throws()
+    {
+        var s = SeedSession();
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "a.cs", chunkIndex: 2));
+    }
+
+    [Fact]
+    public async Task RefetchChunkIndexZero_Throws()
+    {
+        var s = SeedSession();
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "a.cs", chunkIndex: 0));
+    }
+
+    [Fact]
+    public async Task RefetchFileNotInSession_Throws()
+    {
+        var s = SeedSession();
+        await Assert.ThrowsAsync<McpException>(() => _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "ghost.cs"));
+    }
+
+    [Fact]
+    public async Task RefetchOnSubmittedSession_StillSucceeds()
+    {
+        var s = SeedSession();
+        s.Submit("done", false, DateTimeOffset.UtcNow);
+        var blocks = await _handler.ExecuteAsync(sessionId: s.SessionId, filePath: "a.cs");
+        Assert.Contains("[REFETCH]", TextOf(blocks));
+    }
+}

--- a/REBUSS.Pure/Services/ReviewSession/ReviewSession.cs
+++ b/REBUSS.Pure/Services/ReviewSession/ReviewSession.cs
@@ -37,6 +37,12 @@ public sealed class ReviewSession
         _byPath = files.ToDictionary(f => f.Path, StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>Maximum number of results returned by <see cref="QueryObservations"/>. (FR-016)</summary>
+    public const int MaxQueryLimit = 20;
+
+    /// <summary>Per-result truncation cap for observation text in query responses. (FR-017)</summary>
+    public const int MaxObservationCharsInResult = 2000;
+
     public string SessionId { get; }
     public int PrNumber { get; }
     public string HeadSha { get; }
@@ -202,7 +208,130 @@ public sealed class ReviewSession
                 unacked);
         }
     }
+
+    /// <summary>
+    /// Refetches the content of a previously-delivered file. PURE READ — never
+    /// mutates any session field. See feature 013 spec FR-001 through FR-011.
+    /// </summary>
+    public RefetchResult Refetch(string filePath, int chunkIndex)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(filePath);
+        lock (_lock)
+        {
+            if (!_byPath.TryGetValue(filePath, out var file))
+                return new RefetchResult(RefetchKind.FileNotInSession, null, null, 0, 0);
+
+            if (file.Status == ReviewItemStatus.Pending)
+                return new RefetchResult(RefetchKind.FilePending, file, null, 0, 0);
+
+            if (file.Status == ReviewItemStatus.DeliveredPartial)
+                return new RefetchResult(RefetchKind.FilePartial, file, null, 0, 0);
+
+            // Acknowledged states: DeliveredAwaitingObservation, ReviewedComplete, SkippedWithReason.
+            if (file.Chunks is { } chunks && chunks.Count > 0)
+            {
+                if (chunkIndex < 1 || chunkIndex > chunks.Count)
+                    return new RefetchResult(RefetchKind.ChunkOutOfRange, file, null, chunkIndex, chunks.Count);
+
+                return new RefetchResult(RefetchKind.Ok, file, chunks[chunkIndex - 1], chunkIndex, chunks.Count);
+            }
+
+            // Unchunked file: only chunkIndex == 1 is valid (explicit decision in plan.md Phase 3).
+            if (chunkIndex != 1)
+                return new RefetchResult(RefetchKind.ChunkOutOfRange, file, null, chunkIndex, 1);
+
+            if (!_enrichedByPath.TryGetValue(file.Path, out var enriched) || enriched is null)
+                return new RefetchResult(RefetchKind.EnrichmentMissing, file, null, 0, 0);
+
+            return new RefetchResult(RefetchKind.Ok, file, enriched, 1, 1);
+        }
+    }
+
+    /// <summary>
+    /// Free-text query over the session's recorded observations. PURE READ.
+    /// See FR-012 through FR-020.
+    /// </summary>
+    public QueryResult QueryObservations(string? query, int limit)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return new QueryResult(QueryKind.EmptyQuery, Array.Empty<QueryResultEntry>(), 0);
+
+        var effectiveLimit = Math.Clamp(limit, 1, MaxQueryLimit);
+        var tokens = query
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(t => t.ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+
+        lock (_lock)
+        {
+            var matches = new List<QueryResultEntry>();
+            foreach (var file in Files)
+            {
+                foreach (var obs in file.Observations)
+                {
+                    var lowerText = obs.Text.ToLowerInvariant();
+                    int score = tokens.Count(t => lowerText.Contains(t, StringComparison.Ordinal));
+                    if (score == 0) continue;
+
+                    var truncated = obs.Text.Length > MaxObservationCharsInResult;
+                    var text = truncated ? obs.Text[..MaxObservationCharsInResult] : obs.Text;
+                    matches.Add(new QueryResultEntry(
+                        file.Path,
+                        file.Status,
+                        obs.SequenceNumber,
+                        text,
+                        truncated,
+                        score));
+                }
+            }
+
+            var ordered = matches
+                .OrderByDescending(e => e.MatchScore)
+                .ThenBy(e => e.FilePath, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var top = ordered.Take(effectiveLimit).ToList();
+            return new QueryResult(QueryKind.Ok, top, ordered.Count);
+        }
+    }
 }
+
+public enum RefetchKind
+{
+    Ok,
+    FileNotInSession,
+    FilePending,
+    FilePartial,
+    ChunkOutOfRange,
+    EnrichmentMissing,
+}
+
+public sealed record RefetchResult(
+    RefetchKind Kind,
+    ReviewFileEntry? File,
+    string? Content,
+    int ChunkIndex,
+    int TotalChunks);
+
+public enum QueryKind
+{
+    Ok,
+    EmptyQuery,
+}
+
+public sealed record QueryResultEntry(
+    string FilePath,
+    ReviewItemStatus Status,
+    int SequenceNumber,
+    string Text,
+    bool IsTruncated,
+    int MatchScore);
+
+public sealed record QueryResult(
+    QueryKind Kind,
+    IReadOnlyList<QueryResultEntry> Entries,
+    int TotalMatches);
 
 public enum NextItemKind
 {

--- a/REBUSS.Pure/Tools/QueryReviewNotesToolHandler.cs
+++ b/REBUSS.Pure/Tools/QueryReviewNotesToolHandler.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Free-text searches a review session's recorded observations. Pure read.
+/// MVP scoring: count of distinct query tokens appearing as case-insensitive
+/// substrings, tie-broken alphabetically by file path. See feature 013 spec
+/// FR-012 through FR-020.
+/// </summary>
+[McpServerToolType]
+public class QueryReviewNotesToolHandler
+{
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly ILogger<QueryReviewNotesToolHandler> _logger;
+
+    public QueryReviewNotesToolHandler(
+        IReviewSessionStore sessionStore,
+        ILogger<QueryReviewNotesToolHandler> logger)
+    {
+        _sessionStore = sessionStore;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "query_review_notes"), Description(
+        "Searches the agent's previously-recorded review observations across the session " +
+        "for free-text matches. Pure read. Use before submit_pr_review to compose a final " +
+        "review from accumulated observations. Limit defaults to 5, capped at 20.")]
+    public Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("Review session id from begin_pr_review")] string? sessionId = null,
+        [Description("Free-text query — whitespace-tokenized, case-insensitive substring match")] string? query = null,
+        [Description("Maximum number of results (default 5, max 20)")] int limit = 5,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new McpException("sessionId is required.");
+        if (query is null)
+            throw new McpException("query is required.");
+
+        if (!_sessionStore.TryGet(sessionId, out var session))
+            return Text(PlainTextFormatter.FormatSessionNotFoundError(sessionId));
+
+        var result = session.QueryObservations(query, limit);
+        switch (result.Kind)
+        {
+            case QueryKind.EmptyQuery:
+                throw new McpException("query must contain at least one non-whitespace character.");
+            case QueryKind.Ok:
+                if (result.Entries.Count == 0)
+                {
+                    _logger.LogInformation("query_review_notes: session {Sid} query='{Q}' returned 0 matches", sessionId, query);
+                    return Text(PlainTextFormatter.FormatNoMatchesResponse(query));
+                }
+                _logger.LogInformation("query_review_notes: session {Sid} query='{Q}' returned {N} of {Total} matches",
+                    sessionId, query, result.Entries.Count, result.TotalMatches);
+                return Text(PlainTextFormatter.FormatQueryResponse(query, result, limit));
+        }
+        throw new McpException("Unknown query state.");
+    }
+
+    private static Task<IEnumerable<ContentBlock>> Text(string s) =>
+        Task.FromResult<IEnumerable<ContentBlock>>(new[] { new TextContentBlock { Text = s } });
+}

--- a/REBUSS.Pure/Tools/RefetchReviewItemToolHandler.cs
+++ b/REBUSS.Pure/Tools/RefetchReviewItemToolHandler.cs
@@ -1,0 +1,74 @@
+using System.ComponentModel;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using REBUSS.Pure.Services.ReviewSession;
+using REBUSS.Pure.Tools.Shared;
+
+namespace REBUSS.Pure.Tools;
+
+/// <summary>
+/// Re-fetches a previously-delivered file from a review session. Pure read —
+/// never mutates session state and never re-runs enrichment. Honors the
+/// acknowledgment gate by refusing to return content for files in Pending or
+/// DeliveredPartial state. See feature 013 spec FR-001 through FR-011.
+/// </summary>
+[McpServerToolType]
+public class RefetchReviewItemToolHandler
+{
+    private readonly IReviewSessionStore _sessionStore;
+    private readonly ILogger<RefetchReviewItemToolHandler> _logger;
+
+    public RefetchReviewItemToolHandler(
+        IReviewSessionStore sessionStore,
+        ILogger<RefetchReviewItemToolHandler> logger)
+    {
+        _sessionStore = sessionStore;
+        _logger = logger;
+    }
+
+    [McpServerTool(Name = "refetch_review_item"), Description(
+        "Re-reads any acknowledged file's exact original content from a review session. " +
+        "Pure read; never re-runs enrichment and never changes session state. " +
+        "For files originally delivered in chunks, pass chunkIndex (default 1) and follow " +
+        "the continuation hint. Refuses Pending or partially-delivered files — use next_review_item for those.")]
+    public Task<IEnumerable<ContentBlock>> ExecuteAsync(
+        [Description("Review session id from begin_pr_review")] string? sessionId = null,
+        [Description("Path of the file to refetch")] string? filePath = null,
+        [Description("1-based chunk index (default 1) for files originally delivered in multiple chunks")] int chunkIndex = 1,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            throw new McpException("sessionId is required.");
+        if (string.IsNullOrEmpty(filePath))
+            throw new McpException("filePath is required.");
+
+        if (!_sessionStore.TryGet(sessionId, out var session))
+            return Text(PlainTextFormatter.FormatSessionNotFoundError(sessionId));
+
+        var result = session.Refetch(filePath, chunkIndex);
+        switch (result.Kind)
+        {
+            case RefetchKind.Ok:
+                _logger.LogInformation("refetch_review_item: session {Sid} {Path} chunk {C}/{T}",
+                    sessionId, filePath, result.ChunkIndex, result.TotalChunks);
+                return Text(PlainTextFormatter.FormatRefetchResponse(
+                    result.File!, result.Content!, result.ChunkIndex, result.TotalChunks, sessionId));
+            case RefetchKind.FileNotInSession:
+                throw new McpException($"File '{filePath}' is not part of review session {sessionId}.");
+            case RefetchKind.FilePending:
+                throw new McpException($"File '{filePath}' has not been fetched yet. Use next_review_item to receive files in the prescribed order.");
+            case RefetchKind.FilePartial:
+                throw new McpException($"File '{filePath}' is still being delivered chunk-by-chunk via next_review_item. Finish that flow before using refetch_review_item.");
+            case RefetchKind.ChunkOutOfRange:
+                throw new McpException($"Chunk index {chunkIndex} is out of range for file '{filePath}' (valid range: 1..{result.TotalChunks}).");
+            case RefetchKind.EnrichmentMissing:
+                throw new McpException($"Enriched content for '{filePath}' is unavailable in this session. The session may have been corrupted; call begin_pr_review for a fresh session.");
+        }
+        throw new McpException("Unknown refetch state.");
+    }
+
+    private static Task<IEnumerable<ContentBlock>> Text(string s) =>
+        Task.FromResult<IEnumerable<ContentBlock>>(new[] { new TextContentBlock { Text = s } });
+}

--- a/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
+++ b/REBUSS.Pure/Tools/Shared/PlainTextFormatter.cs
@@ -379,6 +379,65 @@ internal static class PlainTextFormatter
         return sb.ToString().TrimEnd();
     }
 
+    // ─── Feature 013: Refetch + Query ─────────────────────────────────────────────
+
+    public static string FormatRefetchResponse(
+        Services.ReviewSession.ReviewFileEntry file,
+        string content,
+        int chunkIndex,
+        int totalChunks,
+        string sessionId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("[REFETCH]");
+        sb.AppendLine($"=== {file.Path} ===");
+        if (totalChunks > 1)
+            sb.AppendLine($"Chunk {chunkIndex} of {totalChunks}  |  state: {file.Status}");
+        else
+            sb.AppendLine($"State: {file.Status}");
+        sb.AppendLine();
+        sb.AppendLine(content);
+        sb.AppendLine();
+        if (totalChunks > 1 && chunkIndex < totalChunks)
+            sb.Append($"--- More chunks remain. Call refetch_review_item with sessionId={sessionId}, filePath=\"{file.Path}\", chunkIndex={chunkIndex + 1} to continue.");
+        else
+            sb.Append("--- End of refetched content. This call did not change session state.");
+        return sb.ToString();
+    }
+
+    public static string FormatQueryResponse(
+        string query,
+        Services.ReviewSession.QueryResult result,
+        int requestedLimit)
+    {
+        var sb = new StringBuilder();
+        var shown = result.Entries.Count;
+        sb.AppendLine($"Query: '{query}'  |  {result.TotalMatches} match(es) total  |  showing top {shown}");
+        sb.AppendLine();
+
+        for (int i = 0; i < result.Entries.Count; i++)
+        {
+            var e = result.Entries[i];
+            sb.AppendLine($"  [{i + 1}] {e.FilePath}  ({e.Status}, observation #{e.SequenceNumber})");
+            foreach (var line in e.Text.Split('\n'))
+                sb.AppendLine($"      {line}");
+            if (e.IsTruncated)
+                sb.AppendLine($"      ... [truncated at {Services.ReviewSession.ReviewSession.MaxObservationCharsInResult} chars]");
+            sb.AppendLine();
+        }
+
+        if (result.TotalMatches > shown)
+            sb.Append($"--- {result.TotalMatches - shown} additional match(es) not shown. Increase 'limit' (max 20) or refine the query.");
+        else
+            sb.Append("--- End of query results. This call did not change session state.");
+        return sb.ToString();
+    }
+
+    public static string FormatNoMatchesResponse(string query)
+    {
+        return $"Query: '{query}'\nNo observations match this query in the current session.";
+    }
+
     public static string FormatAuditTrail(
         Services.ReviewSession.ReviewSession session,
         string reviewText)


### PR DESCRIPTION
Two new MCP tools (refetch_review_item, query_review_notes) extend the stateful review session with the read side. refetch_review_item re-reads any acknowledged file's exact original content (chunked or not) without re-running enrichment. query_review_notes performs free-text search over the session's append-only observation history with default limit 5, max 20, ~2000-char per-entry truncation. Both are pure reads under the existing per-session lock - no state mutation, no audit-trail entries, no widening of feature 012's Principle VI exception.