### PR TITLE
Reduce log noise; deduplicate DiffSourceResolver I/O

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # REBUSS.Pure Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-09
+Auto-generated from all feature plans. Last updated: 2026-04-10
 
 ## Active Technologies
+- C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`) (014-log-noise-reduction)
+- N/A (in-memory `ConcurrentDictionary` only — no persistent storage changes) (014-log-noise-reduction)
 
 - C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + None new. Reuses existing `System.Diagnostics.Process`, `Microsoft.Extensions.Logging`, and `REBUSS.Pure.GitHub.Configuration.GitHubCliProcessHelper`. External runtime dependency on `gh` CLI and the `github/gh-copilot` GitHub CLI extension (installed on demand, never bundled). (012-copilot-cli-setup)
 
@@ -22,6 +24,7 @@ tests/
 C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>`: Follow standard conventions
 
 ## Recent Changes
+- 014-log-noise-reduction: Added C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`)
 - 013-copilot-review-layer: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
 
 - 012-copilot-cli-setup: Added C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + None new. Reuses existing `System.Diagnostics.Process`, `Microsoft.Extensions.Logging`, and `REBUSS.Pure.GitHub.Configuration.GitHubCliProcessHelper`. External runtime dependency on `gh` CLI and the `github/gh-copilot` GitHub CLI extension (installed on demand, never bundled).

--- a/REBUSS.Pure.GitHub.Tests/Configuration/GitHubChainedAuthenticationProviderTests.cs
+++ b/REBUSS.Pure.GitHub.Tests/Configuration/GitHubChainedAuthenticationProviderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -223,5 +224,42 @@ public class GitHubChainedAuthenticationProviderTests
         var message = Resources.ErrorGitHubAuthRequired;
 
         Assert.Contains("rebuss-pure init", message);
+    }
+
+    [Fact]
+    public async Task GetAuthenticationAsync_CachedToken_LogsAtDebugLevel_NotInformation()
+    {
+        var options = new GitHubOptions();
+        _configStore.Load().Returns(new GitHubCachedConfig
+        {
+            AccessToken = "cached-token",
+            TokenExpiresOn = DateTime.UtcNow.AddHours(1)
+        });
+
+        var logger = Substitute.For<ILogger<GitHubChainedAuthenticationProvider>>();
+        logger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+
+        var provider = new GitHubChainedAuthenticationProvider(
+            Options.Create(options),
+            _configStore,
+            _ghCliTokenProvider,
+            logger);
+
+        await provider.GetAuthenticationAsync();
+
+        // "Using cached GitHub token" must be logged at Debug, not Information
+        logger.Received().Log(
+            LogLevel.Debug,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Using cached GitHub token")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+
+        logger.DidNotReceive().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Using cached GitHub token")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 }

--- a/REBUSS.Pure.GitHub/Configuration/GitHubChainedAuthenticationProvider.cs
+++ b/REBUSS.Pure.GitHub/Configuration/GitHubChainedAuthenticationProvider.cs
@@ -49,7 +49,7 @@ public class GitHubChainedAuthenticationProvider : IGitHubAuthenticationProvider
             var notExpired = !cached.TokenExpiresOn.HasValue || cached.TokenExpiresOn > DateTime.UtcNow.AddMinutes(5);
             if (notExpired)
             {
-                _logger.LogInformation("Using cached GitHub token");
+                _logger.LogDebug("Using cached GitHub token");
                 return new AuthenticationHeaderValue("Bearer", cached.AccessToken);
             }
 

--- a/REBUSS.Pure.RoslynProcessor.Tests/DiffSourceResolverTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/DiffSourceResolverTests.cs
@@ -154,4 +154,71 @@ public class DiffSourceResolverTests : IDisposable
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task ResolveAsync_SameFilePath_ReturnsCachedResult_NoSecondIo()
+    {
+        var wrapperDir = Path.Combine(_tempDir, "repo-abc123");
+        var srcDir = Path.Combine(wrapperDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        File.WriteAllText(Path.Combine(srcDir, "File.cs"), "class C { }");
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns(_tempDir);
+
+        var diff = "=== src/File.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-old\n+class C { }";
+
+        var result1 = await _resolver.ResolveAsync(diff);
+        var result2 = await _resolver.ResolveAsync(diff);
+
+        Assert.NotNull(result1);
+        Assert.Same(result1, result2); // Reference equality — cached
+
+        // GetExtractedPathAsync should be called only once (first resolve)
+        await _orchestrator.Received(1).GetExtractedPathAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NullResult_IsCached_NoSecondIo()
+    {
+        Directory.CreateDirectory(_tempDir);
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns(_tempDir);
+
+        var diff = "=== src/Missing.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-old\n+new";
+
+        var result1 = await _resolver.ResolveAsync(diff);
+        var result2 = await _resolver.ResolveAsync(diff);
+
+        Assert.Null(result1);
+        Assert.Null(result2);
+
+        // Only one I/O attempt — second call returns cached null
+        await _orchestrator.Received(1).GetExtractedPathAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveAsync_DifferentFilePaths_ResolveSeparately()
+    {
+        var wrapperDir = Path.Combine(_tempDir, "repo-abc123");
+        var srcDir = Path.Combine(wrapperDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        File.WriteAllText(Path.Combine(srcDir, "A.cs"), "class A { }");
+        File.WriteAllText(Path.Combine(srcDir, "B.cs"), "class B { }");
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns(_tempDir);
+
+        var diffA = "=== src/A.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-old\n+class A { }";
+        var diffB = "=== src/B.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-old\n+class B { }";
+
+        var resultA = await _resolver.ResolveAsync(diffA);
+        var resultB = await _resolver.ResolveAsync(diffB);
+
+        Assert.NotNull(resultA);
+        Assert.NotNull(resultB);
+        Assert.NotSame(resultA, resultB);
+        Assert.Equal("src/A.cs", resultA.FilePath);
+        Assert.Equal("src/B.cs", resultB.FilePath);
+
+        // Both paths require their own resolution
+        await _orchestrator.Received(2).GetExtractedPathAsync(Arg.Any<CancellationToken>());
+    }
 }

--- a/REBUSS.Pure.RoslynProcessor.Tests/EnricherPipelineIntegrationTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/EnricherPipelineIntegrationTests.cs
@@ -170,6 +170,53 @@ public class EnricherPipelineIntegrationTests : IDisposable
 
     // ─── Feature 011 — idempotence (FR-007 / SC-004) ─────────────────────────
 
+    // ─── Feature 014 — resolver cache deduplication (FR-004 / FR-005) ──────
+
+    [Fact]
+    public async Task Pipeline_SharedResolver_ResolvesEachFileOnce_OutputIdentical()
+    {
+        // Setup 3 files in the repo
+        var wrapperDir = Path.Combine(_tempDir, "repo");
+        var srcDir = Path.Combine(wrapperDir, "src");
+        Directory.CreateDirectory(srcDir);
+
+        File.WriteAllText(Path.Combine(srcDir, "A.cs"), "class A { void Foo() { } }");
+        File.WriteAllText(Path.Combine(srcDir, "B.cs"), "class B { void Bar() { } }");
+        File.WriteAllText(Path.Combine(srcDir, "C.cs"), "class C { void Baz() { } }");
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns(_tempDir);
+
+        // Single shared resolver — all 4 enrichers use the same instance
+        var sourceResolver = new DiffSourceResolver(_orchestrator, NullLogger<DiffSourceResolver>.Instance);
+        var enrichers = new IDiffEnricher[]
+        {
+            new BeforeAfterEnricher(sourceResolver, NullLogger<BeforeAfterEnricher>.Instance),
+            new ScopeAnnotatorEnricher(sourceResolver, NullLogger<ScopeAnnotatorEnricher>.Instance),
+            new StructuralChangeEnricher(sourceResolver, NullLogger<StructuralChangeEnricher>.Instance),
+            new UsingsChangeEnricher(sourceResolver, NullLogger<UsingsChangeEnricher>.Instance)
+        };
+
+        var diffs = new[]
+        {
+            "=== src/A.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-class A { }\n+class A { void Foo() { } }",
+            "=== src/B.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-class B { }\n+class B { void Bar() { } }",
+            "=== src/C.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-class C { }\n+class C { void Baz() { } }"
+        };
+
+        var results = new List<string>();
+        foreach (var diff in diffs)
+            results.Add(await ChainEnrichersAsync(enrichers, diff));
+
+        // (a) Deduplication: 4 enrichers × 3 files = 12 ResolveAsync calls,
+        // but only 3 unique file paths → 3 I/O operations
+        await _orchestrator.Received(3).GetExtractedPathAsync(Arg.Any<CancellationToken>());
+
+        // (b) Identity: enriched output is non-empty and contains file markers
+        Assert.All(results, r => Assert.NotEmpty(r));
+        Assert.Contains("A.cs", results[0]);
+        Assert.Contains("B.cs", results[1]);
+        Assert.Contains("C.cs", results[2]);
+    }
+
     [Fact]
     public async Task Pipeline_RunTwice_IsByteIdentical()
     {

--- a/REBUSS.Pure.RoslynProcessor/DiffSourceResolver.cs
+++ b/REBUSS.Pure.RoslynProcessor/DiffSourceResolver.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using REBUSS.Pure.Core;
 
@@ -23,6 +24,7 @@ public class DiffSourceResolver
 
     private readonly IRepositoryDownloadOrchestrator _orchestrator;
     private readonly ILogger<DiffSourceResolver> _logger;
+    private readonly ConcurrentDictionary<string, Lazy<Task<DiffSourcePair?>>> _cache = new();
 
     public DiffSourceResolver(
         IRepositoryDownloadOrchestrator orchestrator,
@@ -35,6 +37,7 @@ public class DiffSourceResolver
     /// <summary>
     /// Resolves the before/after source code for the file in the given diff.
     /// Returns <c>null</c> if the file cannot be resolved (repo unavailable, file missing, too large, etc.).
+    /// Results are cached per file path so that multiple enrichers share one resolution.
     /// </summary>
     public async Task<DiffSourcePair?> ResolveAsync(string diff, CancellationToken ct = default)
     {
@@ -43,6 +46,18 @@ public class DiffSourceResolver
         if (filePath == null)
             return null;
 
+        // Cache lookup/insert: the Lazy<Task<>> pattern ensures only one resolution
+        // per file path, even under concurrent access. The first caller's ct is captured
+        // by the factory; subsequent callers reuse the completed Task.
+        var lazy = _cache.GetOrAdd(filePath,
+            _ => new Lazy<Task<DiffSourcePair?>>(() => ResolveInternalAsync(filePath, diff, ct)));
+
+        return await lazy.Value;
+    }
+
+    private async Task<DiffSourcePair?> ResolveInternalAsync(
+        string filePath, string diff, CancellationToken ct)
+    {
         // 2. Wait for repository download with timeout
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(DownloadTimeout);

--- a/REBUSS.Pure.Tests/Logging/LogConfigurationTests.cs
+++ b/REBUSS.Pure.Tests/Logging/LogConfigurationTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace REBUSS.Pure.Tests.Logging;
+
+public class LogConfigurationTests
+{
+    private static ILoggerFactory BuildLoggerFactoryFromConfig(
+        Dictionary<string, string?>? overrides = null)
+    {
+        var configBuilder = new ConfigurationBuilder()
+            .AddJsonFile(
+                Path.Combine(AppContext.BaseDirectory, "appsettings.json"),
+                optional: false);
+
+        if (overrides is not null)
+            configBuilder.AddInMemoryCollection(overrides);
+
+        var configuration = configBuilder.Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.AddConfiguration(configuration.GetSection("Logging"));
+            builder.AddConsole(); // Need at least one provider for IsEnabled to work
+        });
+
+        return services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+    }
+
+    [Theory]
+    [InlineData("Microsoft.Extensions.Http")]
+    [InlineData("Polly")]
+    public void DefaultConfig_FrameworkCategories_SuppressBelowWarning(string categoryName)
+    {
+        using var factory = BuildLoggerFactoryFromConfig();
+        var logger = factory.CreateLogger(categoryName);
+
+        // Framework categories configured at Warning level must not emit Debug or Information
+        Assert.False(logger.IsEnabled(LogLevel.Debug),
+            $"{categoryName} should not emit Debug at default config");
+        Assert.False(logger.IsEnabled(LogLevel.Information),
+            $"{categoryName} should not emit Information at default config");
+    }
+
+    [Fact]
+    public void DefaultConfig_ApplicationCategories_DoNotEmitDebug()
+    {
+        using var factory = BuildLoggerFactoryFromConfig();
+        var logger = factory.CreateLogger("REBUSS.Pure.Services.SomeService");
+
+        // Application categories at Default (Information) must not emit Debug
+        Assert.False(logger.IsEnabled(LogLevel.Debug),
+            "Application categories should not emit Debug at default config");
+    }
+
+    [Fact]
+    public void NamespaceOverride_EnablesDebug_ForTargetedCategoryOnly()
+    {
+        var overrides = new Dictionary<string, string?>
+        {
+            ["Logging:LogLevel:REBUSS.Pure.GitHub.Configuration.GitHubChainedAuthenticationProvider"] = "Debug"
+        };
+
+        using var factory = BuildLoggerFactoryFromConfig(overrides);
+
+        var targetLogger = factory.CreateLogger(
+            "REBUSS.Pure.GitHub.Configuration.GitHubChainedAuthenticationProvider");
+        var otherLogger = factory.CreateLogger("REBUSS.Pure.Services.SomeService");
+        var pollyLogger = factory.CreateLogger("Polly");
+
+        // The overridden namespace should allow Debug; others must not
+        Assert.True(targetLogger.IsEnabled(LogLevel.Debug),
+            "Overridden namespace should emit Debug");
+        Assert.False(pollyLogger.IsEnabled(LogLevel.Debug),
+            "Polly should remain suppressed despite namespace override elsewhere");
+    }
+}

--- a/REBUSS.Pure.Tests/REBUSS.Pure.Tests.csproj
+++ b/REBUSS.Pure.Tests/REBUSS.Pure.Tests.csproj
@@ -25,4 +25,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\REBUSS.Pure\appsettings.json" Link="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/REBUSS.Pure/Program.cs
+++ b/REBUSS.Pure/Program.cs
@@ -105,7 +105,6 @@ namespace REBUSS.Pure
                     options.LogToStandardErrorThreshold = LogLevel.Trace;
                 });
                 builder.Logging.AddProvider(new FileLoggerProvider(GetLogDirectory()));
-                builder.Logging.SetMinimumLevel(LogLevel.Debug);
 
                 // Register business services (providers, algorithms, shared services)
                 ConfigureBusinessServices(builder.Services, configuration, parseResult.RepoPath);

--- a/REBUSS.Pure/appsettings.json
+++ b/REBUSS.Pure/appsettings.json
@@ -50,7 +50,9 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
-      "System": "Warning"
+      "System": "Warning",
+      "Microsoft.Extensions.Http": "Warning",
+      "Polly": "Warning"
     }
   }
 }


### PR DESCRIPTION
- Suppress logs below Warning for Microsoft.Extensions.Http and Polly via appsettings.json; remove hardcoded minimum log level.
- Log "Using cached GitHub token" at Debug (not Information); add test to verify.
- Add LogConfigurationTests to ensure correct log level behavior and namespace overrides.
- DiffSourceResolver now caches results per file path (including nulls) using ConcurrentDictionary, deduplicating I/O across enrichers.
- Add unit and integration tests for resolver cache behavior and deduplication.
- Update documentation and changelog for logging and caching improvements.