### PR TITLE
Optimize PR API calls, add Copilot eager init & tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-10
 ## Active Technologies
 - C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`) (014-log-noise-reduction)
 - N/A (in-memory `ConcurrentDictionary` only — no persistent storage changes) (014-log-noise-reduction)
+- C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + `GitHubApiClient` (HTTP via `IHttpClientFactory`), `GitHubDiffProvider`, `CopilotClientProvider` (Copilot SDK), `CopilotReviewOptions` (015-api-call-optimization)
+- N/A (in-memory `ConcurrentDictionary` cache only) (015-api-call-optimization)
 
 - C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + None new. Reuses existing `System.Diagnostics.Process`, `Microsoft.Extensions.Logging`, and `REBUSS.Pure.GitHub.Configuration.GitHubCliProcessHelper`. External runtime dependency on `gh` CLI and the `github/gh-copilot` GitHub CLI extension (installed on demand, never bundled). (012-copilot-cli-setup)
 
@@ -24,10 +26,10 @@ tests/
 C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>`: Follow standard conventions
 
 ## Recent Changes
+- 015-api-call-optimization: Added C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + `GitHubApiClient` (HTTP via `IHttpClientFactory`), `GitHubDiffProvider`, `CopilotClientProvider` (Copilot SDK), `CopilotReviewOptions`
 - 014-log-noise-reduction: Added C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`)
 - 013-copilot-review-layer: Added [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
 
-- 012-copilot-cli-setup: Added C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + None new. Reuses existing `System.Diagnostics.Process`, `Microsoft.Extensions.Logging`, and `REBUSS.Pure.GitHub.Configuration.GitHubCliProcessHelper`. External runtime dependency on `gh` CLI and the `github/gh-copilot` GitHub CLI extension (installed on demand, never bundled).
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->

--- a/REBUSS.Pure.GitHub.Tests/Api/GitHubApiClientCacheTests.cs
+++ b/REBUSS.Pure.GitHub.Tests/Api/GitHubApiClientCacheTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using REBUSS.Pure.GitHub.Api;
+using REBUSS.Pure.GitHub.Configuration;
+
+namespace REBUSS.Pure.GitHub.Tests.Api;
+
+/// <summary>
+/// Tests for the static PR details cache in <see cref="GitHubApiClient"/>.
+/// Uses unique PR numbers per test to avoid cross-test interference from the static cache.
+/// </summary>
+public class GitHubApiClientCacheTests
+{
+    private static int _nextPrNumber = 10000; // High base to avoid collisions with other tests
+
+    private static int UniquePrNumber() => Interlocked.Increment(ref _nextPrNumber);
+
+    private static GitHubApiClient CreateClient(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.com/")
+        };
+
+        var options = Options.Create(new GitHubOptions
+        {
+            Owner = "test-owner",
+            RepositoryName = "test-repo"
+        });
+
+        return new GitHubApiClient(httpClient, options, NullLogger<GitHubApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPullRequestDetailsAsync_SecondCall_ReturnsCached_NoHttpRequest()
+    {
+        var prNumber = UniquePrNumber();
+        var callCount = 0;
+        var handler = new FakeHandler(_ =>
+        {
+            Interlocked.Increment(ref callCount);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"number\":{prNumber},\"title\":\"test\"}}")
+            };
+        });
+
+        var client = CreateClient(handler);
+
+        var first = await client.GetPullRequestDetailsAsync(prNumber);
+        var second = await client.GetPullRequestDetailsAsync(prNumber);
+
+        Assert.Equal(first, second);
+        Assert.Equal(1, callCount); // HTTP called only once
+    }
+
+    [Fact]
+    public async Task GetPullRequestDetailsAsync_DifferentPrNumbers_FetchSeparately()
+    {
+        var pr1 = UniquePrNumber();
+        var pr2 = UniquePrNumber();
+        var callCount = 0;
+        var handler = new FakeHandler(req =>
+        {
+            Interlocked.Increment(ref callCount);
+            var num = req.RequestUri!.Segments[^1];
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent($"{{\"number\":{num},\"title\":\"pr-{num}\"}}")
+            };
+        });
+
+        var client = CreateClient(handler);
+
+        var result1 = await client.GetPullRequestDetailsAsync(pr1);
+        var result2 = await client.GetPullRequestDetailsAsync(pr2);
+
+        Assert.NotEqual(result1, result2);
+        Assert.Contains($"{pr1}", result1);
+        Assert.Contains($"{pr2}", result2);
+        Assert.Equal(2, callCount); // Each PR fetched once
+    }
+
+    private sealed class FakeHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _factory;
+
+        public FakeHandler(Func<HttpRequestMessage, HttpResponseMessage> factory) => _factory = factory;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_factory(request));
+    }
+}

--- a/REBUSS.Pure.GitHub.Tests/Providers/GitHubDiffProviderTests.cs
+++ b/REBUSS.Pure.GitHub.Tests/Providers/GitHubDiffProviderTests.cs
@@ -235,6 +235,87 @@ public class GitHubDiffProviderTests
         Assert.Empty(result.Files[0].Hunks);
     }
 
+    // --- Feature 015: Skip base ref fetch for added files ---
+
+    [Fact]
+    public async Task GetDiffAsync_AddedFile_FetchesHeadOnly_NotBase()
+    {
+        _apiClient.GetPullRequestDetailsAsync(42, Arg.Any<CancellationToken>()).Returns(PrDetailsJson);
+        _apiClient.GetPullRequestFilesAsync(42, Arg.Any<CancellationToken>()).Returns("""
+            [{ "filename": "src/New.cs", "status": "added", "additions": 5, "deletions": 0 }]
+            """);
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/New.cs", Arg.Any<CancellationToken>()).Returns("class New { }");
+
+        await _provider.GetDiffAsync(42);
+
+        // Head ref fetched
+        await _apiClient.Received(1).GetFileContentAtRefAsync("aaa111", "src/New.cs", Arg.Any<CancellationToken>());
+        // Base ref NOT fetched
+        await _apiClient.DidNotReceive().GetFileContentAtRefAsync("bbb222", "src/New.cs", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_EditedFile_FetchesBothBaseAndHead()
+    {
+        SetupStandardMocks();
+        _apiClient.GetFileContentAtRefAsync("bbb222", "src/File.cs", Arg.Any<CancellationToken>()).Returns("old");
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/File.cs", Arg.Any<CancellationToken>()).Returns("new");
+
+        await _provider.GetDiffAsync(42);
+
+        // Both base and head fetched
+        await _apiClient.Received(1).GetFileContentAtRefAsync("bbb222", "src/File.cs", Arg.Any<CancellationToken>());
+        await _apiClient.Received(1).GetFileContentAtRefAsync("aaa111", "src/File.cs", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetDiffAsync_MixedFiles_CorrectFetchCounts_AndAddedFileHasOnlyAdditions()
+    {
+        _apiClient.GetPullRequestDetailsAsync(42, Arg.Any<CancellationToken>()).Returns(PrDetailsJson);
+        _apiClient.GetPullRequestFilesAsync(42, Arg.Any<CancellationToken>()).Returns("""
+            [
+                { "filename": "src/Add1.cs", "status": "added", "additions": 1, "deletions": 0 },
+                { "filename": "src/Add2.cs", "status": "added", "additions": 1, "deletions": 0 },
+                { "filename": "src/Add3.cs", "status": "added", "additions": 1, "deletions": 0 },
+                { "filename": "src/Edit1.cs", "status": "modified", "additions": 1, "deletions": 1 },
+                { "filename": "src/Edit2.cs", "status": "modified", "additions": 1, "deletions": 1 },
+                { "filename": "src/Del.cs", "status": "removed", "additions": 0, "deletions": 5 }
+            ]
+            """);
+
+        // Setup returns for edit files (both base + head)
+        _apiClient.GetFileContentAtRefAsync("bbb222", "src/Edit1.cs", Arg.Any<CancellationToken>()).Returns("old1");
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/Edit1.cs", Arg.Any<CancellationToken>()).Returns("new1");
+        _apiClient.GetFileContentAtRefAsync("bbb222", "src/Edit2.cs", Arg.Any<CancellationToken>()).Returns("old2");
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/Edit2.cs", Arg.Any<CancellationToken>()).Returns("new2");
+        // Setup returns for add files (head only)
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/Add1.cs", Arg.Any<CancellationToken>()).Returns("class Add1 { }");
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/Add2.cs", Arg.Any<CancellationToken>()).Returns("class Add2 { }");
+        _apiClient.GetFileContentAtRefAsync("aaa111", "src/Add3.cs", Arg.Any<CancellationToken>()).Returns("class Add3 { }");
+
+        var result = await _provider.GetDiffAsync(42);
+
+        // (a) Call counts: 2 base (edits only) + 5 head (3 add + 2 edit) = 7 total
+        var totalCalls = _apiClient.ReceivedCalls()
+            .Count(c => c.GetMethodInfo().Name == nameof(IGitHubApiClient.GetFileContentAtRefAsync));
+        Assert.Equal(7, totalCalls);
+
+        // No base fetch for added files
+        await _apiClient.DidNotReceive().GetFileContentAtRefAsync("bbb222", "src/Add1.cs", Arg.Any<CancellationToken>());
+        await _apiClient.DidNotReceive().GetFileContentAtRefAsync("bbb222", "src/Add2.cs", Arg.Any<CancellationToken>());
+        await _apiClient.DidNotReceive().GetFileContentAtRefAsync("bbb222", "src/Add3.cs", Arg.Any<CancellationToken>());
+
+        // (b) Added files have only '+' lines (FR-005/SC-004 byte-identical output)
+        var addFile = result.Files.First(f => f.Path == "src/Add1.cs");
+        Assert.NotEmpty(addFile.Hunks);
+        var addLines = addFile.Hunks.SelectMany(h => h.Lines).ToList();
+        Assert.All(addLines, l => Assert.Equal('+', l.Op));
+
+        // Delete file is skipped entirely
+        var delFile = result.Files.First(f => f.Path == "src/Del.cs");
+        Assert.NotNull(delFile.SkipReason);
+    }
+
     private void SetupStandardMocks()
     {
         _apiClient.GetPullRequestDetailsAsync(42, Arg.Any<CancellationToken>()).Returns(PrDetailsJson);

--- a/REBUSS.Pure.GitHub/Api/GitHubApiClient.cs
+++ b/REBUSS.Pure.GitHub/Api/GitHubApiClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -18,6 +19,10 @@ public class GitHubApiClient : IGitHubApiClient
     private const int MaxPagesPerEndpoint = 10;
     private const int DefaultPerPage = 100;
 
+    // Static cache: persists across transient GitHubApiClient instances created by IHttpClientFactory.
+    // PR details are immutable within a review cycle (same headSha).
+    private static readonly ConcurrentDictionary<int, string> _prDetailsCache = new();
+
     private readonly HttpClient _httpClient;
     private readonly GitHubOptions _options;
     private readonly ILogger<GitHubApiClient> _logger;
@@ -37,10 +42,18 @@ public class GitHubApiClient : IGitHubApiClient
 
     public async Task<string> GetPullRequestDetailsAsync(int pullRequestNumber, CancellationToken cancellationToken = default)
     {
+        if (_prDetailsCache.TryGetValue(pullRequestNumber, out var cached))
+        {
+            _logger.LogDebug("GetPullRequestDetails cache hit for PR #{PullRequestNumber}", pullRequestNumber);
+            return cached;
+        }
+
         _logger.LogDebug("API call: GetPullRequestDetails for PR #{PullRequestNumber}", pullRequestNumber);
 
         var url = $"repos/{_options.Owner}/{_options.RepositoryName}/pulls/{pullRequestNumber}";
-        return await GetStringAsync(url, "GetPullRequestDetails", cancellationToken);
+        var result = await GetStringAsync(url, "GetPullRequestDetails", cancellationToken);
+        _prDetailsCache.TryAdd(pullRequestNumber, result);
+        return result;
     }
 
     public async Task<string> GetPullRequestFilesAsync(int pullRequestNumber, CancellationToken cancellationToken = default)

--- a/REBUSS.Pure.GitHub/Providers/GitHubDiffProvider.cs
+++ b/REBUSS.Pure.GitHub/Providers/GitHubDiffProvider.cs
@@ -192,12 +192,25 @@ public class GitHubDiffProvider
             {
                 var fileSw = Stopwatch.StartNew();
 
-                var baseContentTask = _apiClient.GetFileContentAtRefAsync(baseCommit, file.Path, ct);
-                var headContentTask = _apiClient.GetFileContentAtRefAsync(headCommit, file.Path, ct);
-                await Task.WhenAll(baseContentTask, headContentTask);
+                string? baseContent;
+                string? headContent;
 
-                var baseContent = await baseContentTask;
-                var headContent = await headContentTask;
+                if (string.Equals(file.ChangeType, "add", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Added files have no base version — skip the fetch that would 404.
+                    baseContent = null;
+                    headContent = await _apiClient.GetFileContentAtRefAsync(headCommit, file.Path, ct);
+                    _logger.LogDebug("Skipping base ref fetch for added file '{FilePath}'", file.Path);
+                }
+                else
+                {
+                    var baseContentTask = _apiClient.GetFileContentAtRefAsync(baseCommit, file.Path, ct);
+                    var headContentTask = _apiClient.GetFileContentAtRefAsync(headCommit, file.Path, ct);
+                    await Task.WhenAll(baseContentTask, headContentTask);
+
+                    baseContent = await baseContentTask;
+                    headContent = await headContentTask;
+                }
                 file.Hunks = _diffBuilder.Build(file.Path, baseContent, headContent);
 
                 if (IsFullFileRewrite(baseContent, headContent, file.Hunks))

--- a/REBUSS.Pure.Tests/Tools/GetPullRequestMetadataToolHandlerTests.cs
+++ b/REBUSS.Pure.Tests/Tools/GetPullRequestMetadataToolHandlerTests.cs
@@ -9,6 +9,8 @@ using REBUSS.Pure.Core.Exceptions;
 using REBUSS.Pure.Core.Models;
 using REBUSS.Pure.Core.Models.Pagination;
 using REBUSS.Pure.Core.Models.ResponsePacking;
+using REBUSS.Pure.Core.Services.CopilotReview;
+using REBUSS.Pure.Services.CopilotReview;
 using REBUSS.Pure.Services.PrEnrichment;
 using REBUSS.Pure.Services.ResponsePacking;
 using REBUSS.Pure.Tools;
@@ -24,6 +26,9 @@ public class GetPullRequestMetadataToolHandlerTests
     private readonly IPageAllocator _pageAllocator = Substitute.For<IPageAllocator>();
     private readonly IOptions<WorkflowOptions> _workflowOptions =
         Options.Create(new WorkflowOptions { MetadataInternalTimeoutMs = 28_000, ContentInternalTimeoutMs = 28_000 });
+    private readonly ICopilotClientProvider _copilotClientProvider = Substitute.For<ICopilotClientProvider>();
+    private readonly IOptions<CopilotReviewOptions> _copilotReviewOptions =
+        Options.Create(new CopilotReviewOptions { Enabled = false });
     private readonly GetPullRequestMetadataToolHandler _handler;
 
     private static readonly FullPullRequestMetadata SampleMetadata = new()
@@ -90,6 +95,8 @@ public class GetPullRequestMetadataToolHandlerTests
             _enrichmentOrchestrator,
             _pageAllocator,
             _workflowOptions,
+            _copilotClientProvider,
+            _copilotReviewOptions,
             NullLogger<GetPullRequestMetadataToolHandler>.Instance);
     }
 
@@ -335,5 +342,42 @@ public class GetPullRequestMetadataToolHandlerTests
         var text = AllText(blocks);
 
         Assert.Contains("... [truncated]", text);
+    }
+
+    // ─── Feature 015: Eager Copilot SDK initialization ───────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_CopilotEnabled_TriggersEagerInit()
+    {
+        var copilotOptions = Options.Create(new CopilotReviewOptions { Enabled = true });
+        var copilotProvider = Substitute.For<ICopilotClientProvider>();
+        copilotProvider.TryEnsureStartedAsync(Arg.Any<CancellationToken>()).Returns(true);
+
+        var handler = new GetPullRequestMetadataToolHandler(
+            _dataProvider, _budgetResolver, _downloadOrchestrator,
+            _enrichmentOrchestrator, _pageAllocator, _workflowOptions,
+            copilotProvider, copilotOptions,
+            NullLogger<GetPullRequestMetadataToolHandler>.Instance);
+
+        await handler.ExecuteAsync(prNumber: 42);
+
+        await copilotProvider.Received(1).TryEnsureStartedAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CopilotDisabled_DoesNotTriggerInit()
+    {
+        var copilotOptions = Options.Create(new CopilotReviewOptions { Enabled = false });
+        var copilotProvider = Substitute.For<ICopilotClientProvider>();
+
+        var handler = new GetPullRequestMetadataToolHandler(
+            _dataProvider, _budgetResolver, _downloadOrchestrator,
+            _enrichmentOrchestrator, _pageAllocator, _workflowOptions,
+            copilotProvider, copilotOptions,
+            NullLogger<GetPullRequestMetadataToolHandler>.Instance);
+
+        await handler.ExecuteAsync(prNumber: 42);
+
+        await copilotProvider.DidNotReceive().TryEnsureStartedAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
@@ -7,7 +7,9 @@ using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using REBUSS.Pure.Core;
 using REBUSS.Pure.Core.Exceptions;
+using REBUSS.Pure.Core.Services.CopilotReview;
 using REBUSS.Pure.Properties;
+using REBUSS.Pure.Services.CopilotReview;
 using REBUSS.Pure.Services.PrEnrichment;
 using REBUSS.Pure.Services.ResponsePacking;
 using REBUSS.Pure.Tools.Shared;
@@ -35,6 +37,8 @@ namespace REBUSS.Pure.Tools
         private readonly IPrEnrichmentOrchestrator _enrichmentOrchestrator;
         private readonly IPageAllocator _pageAllocator;
         private readonly IOptions<WorkflowOptions> _workflowOptions;
+        private readonly ICopilotClientProvider _copilotClientProvider;
+        private readonly IOptions<CopilotReviewOptions> _copilotReviewOptions;
         private readonly ILogger<GetPullRequestMetadataToolHandler> _logger;
 
         public GetPullRequestMetadataToolHandler(
@@ -44,6 +48,8 @@ namespace REBUSS.Pure.Tools
             IPrEnrichmentOrchestrator enrichmentOrchestrator,
             IPageAllocator pageAllocator,
             IOptions<WorkflowOptions> workflowOptions,
+            ICopilotClientProvider copilotClientProvider,
+            IOptions<CopilotReviewOptions> copilotReviewOptions,
             ILogger<GetPullRequestMetadataToolHandler> logger)
         {
             _metadataProvider = metadataProvider;
@@ -52,6 +58,8 @@ namespace REBUSS.Pure.Tools
             _enrichmentOrchestrator = enrichmentOrchestrator;
             _pageAllocator = pageAllocator;
             _workflowOptions = workflowOptions;
+            _copilotClientProvider = copilotClientProvider;
+            _copilotReviewOptions = copilotReviewOptions;
             _logger = logger;
         }
 
@@ -89,6 +97,12 @@ namespace REBUSS.Pure.Tools
                     : metadata.LastMergeSourceCommitId;
                 if (!string.IsNullOrEmpty(downloadCommitRef))
                     _downloadOrchestrator.TriggerDownloadAsync(prNumber.Value, downloadCommitRef);
+
+                // Eager Copilot SDK initialization: start in background so it overlaps with enrichment.
+                // Fire-and-forget — failure is captured in CopilotClientProvider._startException
+                // and surfaced when the review orchestrator actually needs the client.
+                if (_copilotReviewOptions.Value.Enabled)
+                    _ = _copilotClientProvider.TryEnsureStartedAsync(CancellationToken.None);
 
                 (int TotalPages, int TotalFiles, int BudgetPerPage, IReadOnlyList<(int Page, int Count)> ByPage)? paging = null;
                 bool pagingDeferred = false;


### PR DESCRIPTION
- Add static in-memory cache for PR details in GitHubApiClient to reduce redundant API calls.
- Optimize GitHubDiffProvider: fetch only head ref for added files, both refs for modified files.
- Enhance GetPullRequestMetadataToolHandler to support eager Copilot SDK initialization when enabled.
- Add/expand unit tests for caching, diff fetch logic, and Copilot init behavior.
- Update CLAUDE.md with new features and technical notes.