### PR TITLE
Handle asymmetric tree sizes in BeforeAfterAnalyzer

### DIFF
--- a/REBUSS.Pure.RoslynProcessor.Tests/BeforeAfterAnalyzerTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/BeforeAfterAnalyzerTests.cs
@@ -78,4 +78,73 @@ public class BeforeAfterAnalyzerTests
     {
         Assert.Equal(ContextDecision.None, BeforeAfterAnalyzer.Analyze(null!, null!));
     }
+
+    // ─── Feature 016: Asymmetric tree size handling ──────────────────────────
+
+    [Fact]
+    public void Analyze_EmptyBefore_SubstantialAfter_DoesNotThrow_ReturnsNonNone()
+    {
+        var before = "";
+        var after = "namespace Foo { public class Bar { public void Baz() { } } }";
+
+        var result = BeforeAfterAnalyzer.Analyze(before, after);
+
+        Assert.NotEqual(ContextDecision.None, result);
+    }
+
+    [Fact]
+    public void Analyze_ShortBefore_LongAfter_DoesNotThrow_ReturnsNonNone()
+    {
+        var before = "class Foo { }";
+        var after = "class Foo { public void A() { } public void B() { } public void C() { } }";
+
+        var result = BeforeAfterAnalyzer.Analyze(before, after);
+
+        Assert.NotEqual(ContextDecision.None, result);
+    }
+
+    [Fact]
+    public void Analyze_LongBefore_ShortAfter_DoesNotThrow_ReturnsNonNone()
+    {
+        var before = "class Foo { public void A() { } public void B() { } public void C() { } }";
+        var after = "class Foo { }";
+
+        var result = BeforeAfterAnalyzer.Analyze(before, after);
+
+        Assert.NotEqual(ContextDecision.None, result);
+    }
+
+    [Fact]
+    public void Analyze_10xExpansion_DoesNotThrow_ReturnsNonNone()
+    {
+        var before = "class Foo { }";
+        var afterBuilder = new System.Text.StringBuilder("class Foo {\n");
+        for (var i = 0; i < 100; i++)
+            afterBuilder.AppendLine($"  public void Method{i}() {{ }}");
+        afterBuilder.AppendLine("}");
+
+        var result = BeforeAfterAnalyzer.Analyze(before, afterBuilder.ToString());
+
+        Assert.NotEqual(ContextDecision.None, result);
+    }
+
+    [Fact]
+    public void Analyze_InvalidSyntaxBoth_DoesNotThrow()
+    {
+        var ex = Record.Exception(
+            () => BeforeAfterAnalyzer.Analyze("not valid c#", "also not valid {{{"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Analyze_NewMethodAppended_DetectsChange()
+    {
+        var before = "class Foo { public void Bar() { } }";
+        var after = "class Foo { public void Bar() { } public void Baz() { return; } }";
+
+        var result = BeforeAfterAnalyzer.Analyze(before, after);
+
+        Assert.True(result == ContextDecision.Minimal || result == ContextDecision.Full);
+    }
 }

--- a/REBUSS.Pure.RoslynProcessor.Tests/EnricherPipelineIntegrationTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/EnricherPipelineIntegrationTests.cs
@@ -217,6 +217,41 @@ public class EnricherPipelineIntegrationTests : IDisposable
         Assert.Contains("C.cs", results[2]);
     }
 
+    // ─── Feature 016 — analyzer span fix pipeline verification ─────────────
+
+    [Fact]
+    public async Task Pipeline_AsymmetricFileSize_EnrichesSuccessfully()
+    {
+        // After code is 5x longer than before — previously triggered ArgumentOutOfRangeException
+        // in BeforeAfterAnalyzer, causing the enricher to fall back to raw diff.
+        var afterCode = @"class Svc {
+    void A() { var x = 1; }
+    void B() { var y = 2; }
+    void C() { var z = 3; }
+    void D() { Console.WriteLine(); }
+    void E() { return; }
+}";
+        SetupRepo("Svc.cs", afterCode);
+
+        var sourceResolver = new DiffSourceResolver(_orchestrator, NullLogger<DiffSourceResolver>.Instance);
+        var enrichers = new IDiffEnricher[]
+        {
+            new BeforeAfterEnricher(sourceResolver, NullLogger<BeforeAfterEnricher>.Instance),
+            new ScopeAnnotatorEnricher(sourceResolver, NullLogger<ScopeAnnotatorEnricher>.Instance),
+            new StructuralChangeEnricher(sourceResolver, NullLogger<StructuralChangeEnricher>.Instance),
+            new UsingsChangeEnricher(sourceResolver, NullLogger<UsingsChangeEnricher>.Instance)
+        };
+
+        // Short before, much longer after
+        var diff = "=== src/Svc.cs (edit: +6 -1) ===\n@@ -1,1 +1,7 @@\n-class Svc { }\n+class Svc {\n+    void A() { var x = 1; }\n+    void B() { var y = 2; }\n+    void C() { var z = 3; }\n+    void D() { Console.WriteLine(); }\n+    void E() { return; }\n+}";
+        var result = await ChainEnrichersAsync(enrichers, diff);
+
+        // The enricher should have modified the diff (added annotations).
+        // If the analyzer had thrown, the result would equal the raw input unchanged.
+        Assert.NotEqual(diff, result);
+        Assert.Contains("Svc.cs", result);
+    }
+
     [Fact]
     public async Task Pipeline_RunTwice_IsByteIdentical()
     {

--- a/REBUSS.Pure.RoslynProcessor/BeforeAfterAnalyzer.cs
+++ b/REBUSS.Pure.RoslynProcessor/BeforeAfterAnalyzer.cs
@@ -61,7 +61,28 @@ public static class BeforeAfterAnalyzer
             // Check all descendant nodes for differences
             foreach (var afterNode in afterRoot.DescendantNodes())
             {
-                var correspondingBefore = beforeRoot.FindNode(afterNode.Span, getInnermostNodeForTie: true);
+                // Guard: afterNode.Span may reference positions beyond the before tree's extent
+                // (common when after code is longer — new methods, expanded classes).
+                if (afterNode.Span.Start >= beforeRoot.FullSpan.Length ||
+                    afterNode.Span.End > beforeRoot.FullSpan.Length)
+                {
+                    foundStructural = true;
+                    continue;
+                }
+
+                SyntaxNode? correspondingBefore;
+                try
+                {
+                    correspondingBefore = beforeRoot.FindNode(afterNode.Span, getInnermostNodeForTie: true);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    // Defense-in-depth: Roslyn's internal span validation may have edge cases
+                    // not covered by the bounds check above.
+                    foundStructural = true;
+                    continue;
+                }
+
                 if (correspondingBefore != null && SyntaxFactory.AreEquivalent(correspondingBefore, afterNode))
                     continue;
 


### PR DESCRIPTION
Add robust handling for cases where the "after" code is much larger than the "before" code in BeforeAfterAnalyzer, preventing ArgumentOutOfRangeException by checking span bounds and catching exceptions. Add unit tests for highly asymmetric before/after code, invalid syntax, and appended methods. Add an integration test to verify the enrichment pipeline works when after files are much larger. Improves analyzer and pipeline reliability for large code changes.