### PR TITLE
Refactor progress reporting; add diff and API robustness

### DIFF
--- a/.github/CodebaseUnderstanding.md
+++ b/.github/CodebaseUnderstanding.md
@@ -82,6 +82,7 @@ Full codebase context is included below (file-role map, dependency graph, DI reg
 | `REBUSS.Pure.Core\Shared\DiffLanguage.cs` | `DiffLanguage` enum (13 languages + Unknown) + `DiffLanguageDetector` static class: centralized language detection from diff headers; used by all enrichers for `CanEnrich`. Also exposes `IsAlreadyEnriched(string)` for the centralized idempotence short-circuit in `CompositeCodeProcessor` (feature 011) | `DiffLanguageDetector` — `Detect(string)`, `IsCSharp(string)`, `IsSkipped(string)`, `IsAlreadyEnriched(string)` |
 | `REBUSS.Pure.Core\Shared\IFileClassifier.cs` | Interface: file classifier | `FileClassification` |
 | `REBUSS.Pure.Core\Shared\FileClassifier.cs` | Classifies files by path/extension; normalizes paths with leading `/` for pattern matching; review priorities via `ReviewPriorities` constants | `IFileClassifier`, `FileClassification`, `FileCategory`, `ReviewPriorities` |
+| `REBUSS.Pure.Core\Shared\IProgressReporter.cs` | MCP-agnostic progress reporting interface; `ReportAsync(object?, int, int?, string, CancellationToken)` accepts SDK `IProgress<ProgressNotificationValue>`, legacy `ProgressToken`, or `null`; stays free of MCP SDK dependency | `IProgressReporter` |
 
 ### Core exceptions (REBUSS.Pure.Core\Exceptions)
 

--- a/REBUSS.Pure.Core/Shared/IProgressReporter.cs
+++ b/REBUSS.Pure.Core/Shared/IProgressReporter.cs
@@ -2,21 +2,25 @@ namespace REBUSS.Pure.Core.Shared;
 
 /// <summary>
 /// Abstracts MCP progress notification sending. Tool handlers call this to report
-/// step-level progress during multi-step operations. When a progress token is
-/// available from the client request, the implementation sends
-/// <c>notifications/progress</c> via the MCP transport. Each call is also logged
-/// at Information level regardless of token presence.
+/// step-level progress during multi-step operations. Supports two token types:
+/// <list type="bullet">
+/// <item><c>IProgress&lt;ProgressNotificationValue&gt;</c> — SDK-injected; preferred path.
+/// The SDK handles token extraction and notification dispatch automatically.</item>
+/// <item><c>ProgressToken</c> — legacy path; resolves <c>McpServer</c> and sends manually.</item>
+/// </list>
+/// Each call is also logged at Information level regardless of token presence.
 /// </summary>
 public interface IProgressReporter
 {
     /// <summary>
-    /// Reports a progress step. If <paramref name="progressToken"/> is non-null and
-    /// the MCP server is available, sends a <c>notifications/progress</c> notification.
+    /// Reports a progress step. Dispatches via the SDK's <c>IProgress&lt;T&gt;</c> when
+    /// available, otherwise falls back to manual <c>ProgressToken</c> + <c>McpServer</c>.
     /// Always logs the message at Information level.
     /// </summary>
     /// <param name="progressToken">
-    /// Opaque token from the client's request <c>_meta</c>. Pass <c>null</c> when
-    /// the client did not provide a token — no notification is sent, but logging still occurs.
+    /// Pass the SDK-injected <c>IProgress&lt;ProgressNotificationValue&gt;</c> instance
+    /// (preferred), a <c>ProgressToken</c>, or <c>null</c>. When <c>null</c>, no
+    /// notification is sent but logging still occurs.
     /// </param>
     /// <param name="progress">Current step number (0-based start, strictly increasing).</param>
     /// <param name="total">Total number of steps, or <c>null</c> if unknown.</param>

--- a/REBUSS.Pure.GitHub/Api/GitHubApiClient.cs
+++ b/REBUSS.Pure.GitHub/Api/GitHubApiClient.cs
@@ -19,9 +19,10 @@ public class GitHubApiClient : IGitHubApiClient
     private const int MaxPagesPerEndpoint = 10;
     private const int DefaultPerPage = 100;
 
-    // Static cache: persists across transient GitHubApiClient instances created by IHttpClientFactory.
-    // PR details are immutable within a review cycle (same headSha).
+    // Static caches: persist across transient GitHubApiClient instances created by IHttpClientFactory.
+    // PR details and file lists are immutable within a review cycle (same headSha).
     private static readonly ConcurrentDictionary<int, string> _prDetailsCache = new();
+    private static readonly ConcurrentDictionary<int, string> _prFilesCache = new();
 
     private readonly HttpClient _httpClient;
     private readonly GitHubOptions _options;
@@ -58,10 +59,18 @@ public class GitHubApiClient : IGitHubApiClient
 
     public async Task<string> GetPullRequestFilesAsync(int pullRequestNumber, CancellationToken cancellationToken = default)
     {
+        if (_prFilesCache.TryGetValue(pullRequestNumber, out var cached))
+        {
+            _logger.LogDebug("GetPullRequestFiles cache hit for PR #{PullRequestNumber}", pullRequestNumber);
+            return cached;
+        }
+
         _logger.LogDebug("API call: GetPullRequestFiles for PR #{PullRequestNumber}", pullRequestNumber);
 
         var url = $"repos/{_options.Owner}/{_options.RepositoryName}/pulls/{pullRequestNumber}/files";
-        return await GetPaginatedArrayAsync(url, "GetPullRequestFiles", cancellationToken);
+        var result = await GetPaginatedArrayAsync(url, "GetPullRequestFiles", cancellationToken);
+        _prFilesCache.TryAdd(pullRequestNumber, result);
+        return result;
     }
 
     public async Task<string> GetPullRequestCommitsAsync(int pullRequestNumber, CancellationToken cancellationToken = default)

--- a/REBUSS.Pure.RoslynProcessor.Tests/DiffParserTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/DiffParserTests.cs
@@ -229,4 +229,20 @@ public class DiffParserTests
         Assert.Equal(30, h.newCount);
         Assert.Equal(30, h.oldCount);
     }
+
+    [Fact]
+    public void RebuildDiffWithContext_SourceLinesShorterThanContextRange_DoesNotThrow()
+    {
+        // Hunk claims NewStart=10 but sourceLines has only 5 lines.
+        // Before the fix, leading context indexing would throw IndexOutOfRangeException.
+        var diff = "=== src/A.cs (edit: +1 -1) ===\n@@ -10,1 +10,1 @@\n-old\n+new";
+        var sourceLines = Enumerable.Range(1, 5).Select(i => $"line{i}").ToArray();
+        var hunks = DiffParser.ParseHunks(diff);
+
+        var result = DiffParser.RebuildDiffWithContext(diff, sourceLines, hunks, ContextDecision.Full);
+
+        // Should not throw; should still contain the change.
+        Assert.Contains("-old", result);
+        Assert.Contains("+new", result);
+    }
 }

--- a/REBUSS.Pure.RoslynProcessor/DiffParser.cs
+++ b/REBUSS.Pure.RoslynProcessor/DiffParser.cs
@@ -127,8 +127,8 @@ public static partial class DiffParser
             var lines = new List<string>();
 
             // Leading context — sliced from the AFTER file at NEW-axis start.
-            int leadStartIdx = firstHunk.NewStart - 1 - leadingCount;
-            for (int j = 0; j < leadingCount; j++)
+            int leadStartIdx = Math.Max(0, firstHunk.NewStart - 1 - leadingCount);
+            for (int j = 0; j < leadingCount && leadStartIdx + j < sourceLines.Length; j++)
                 lines.Add(" " + sourceLines[leadStartIdx + j]);
 
             for (int hi = 0; hi < cluster.Count; hi++)

--- a/REBUSS.Pure.Tests/Services/ProgressReporterTests.cs
+++ b/REBUSS.Pure.Tests/Services/ProgressReporterTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using NSubstitute;
@@ -68,5 +69,39 @@ public class ProgressReporterTests
             Arg.Is<object>(o => o.ToString()!.Contains("Starting operation")),
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task ReportAsync_WithSdkProgress_DelegatesToIProgressAndDoesNotResolveMcpServer()
+    {
+        var sdkProgress = Substitute.For<IProgress<ProgressNotificationValue>>();
+
+        await _reporter.ReportAsync(sdkProgress, 2, 5, "Enriching files (2/5)");
+
+        // Should delegate to IProgress<T>.Report()
+        sdkProgress.Received(1).Report(Arg.Is<ProgressNotificationValue>(v =>
+            v.Progress == 2 && v.Total == 5 && v.Message == "Enriching files (2/5)"));
+
+        // Should NOT resolve McpServer — SDK path is self-contained
+        _serviceProvider.DidNotReceive().GetService(typeof(McpServer));
+
+        // Should still log
+        _logger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Enriching files (2/5)")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task ReportAsync_WithSdkProgress_NullTotal_ReportsCorrectly()
+    {
+        var sdkProgress = Substitute.For<IProgress<ProgressNotificationValue>>();
+
+        await _reporter.ReportAsync(sdkProgress, 1, null, "Processing...");
+
+        sdkProgress.Received(1).Report(Arg.Is<ProgressNotificationValue>(v =>
+            v.Progress == 1 && v.Total == null && v.Message == "Processing..."));
     }
 }

--- a/REBUSS.Pure/Services/ProgressReporter.cs
+++ b/REBUSS.Pure/Services/ProgressReporter.cs
@@ -8,8 +8,13 @@ namespace REBUSS.Pure.Services;
 
 /// <summary>
 /// Sends MCP <c>notifications/progress</c> via the SDK transport and logs each step
-/// at Information level. Resolves <see cref="McpServer"/> lazily from
-/// <see cref="IServiceProvider"/> because it is not available in CLI mode.
+/// at Information level. Supports two dispatch paths:
+/// <list type="number">
+/// <item>SDK-injected <see cref="IProgress{ProgressNotificationValue}"/> — preferred;
+/// the SDK handles token extraction and notification dispatch automatically.</item>
+/// <item>Legacy <see cref="ProgressToken"/> — resolves <see cref="McpServer"/> lazily
+/// from <see cref="IServiceProvider"/> (unavailable in CLI mode).</item>
+/// </list>
 /// </summary>
 public sealed class ProgressReporter : IProgressReporter
 {
@@ -32,6 +37,20 @@ public sealed class ProgressReporter : IProgressReporter
         // Always log regardless of token (FR-006)
         _logger.LogInformation("{ProgressMessage}", message);
 
+        // Preferred path: SDK-injected IProgress<T> handles token extraction and
+        // notification dispatch automatically. No-ops when client omits progressToken.
+        if (progressToken is IProgress<ProgressNotificationValue> sdkProgress)
+        {
+            sdkProgress.Report(new ProgressNotificationValue
+            {
+                Progress = progress,
+                Total = total,
+                Message = message,
+            });
+            return;
+        }
+
+        // Legacy fallback: explicit ProgressToken + manual McpServer resolution.
         if (progressToken is not ProgressToken token)
             return;
 

--- a/REBUSS.Pure/Tools/GetPullRequestContentToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetPullRequestContentToolHandler.cs
@@ -73,6 +73,7 @@ namespace REBUSS.Pure.Tools
             [Description("Page number to retrieve (1-based)")] int? pageNumber = null,
             [Description("Model name for context budget resolution")] string? modelName = null,
             [Description("Explicit token budget override")] int? maxTokens = null,
+            IProgress<ProgressNotificationValue>? progress = null,
             CancellationToken cancellationToken = default)
         {
             if (prNumber == null)
@@ -89,9 +90,9 @@ namespace REBUSS.Pure.Tools
                 _logger.LogInformation(Resources.LogGetPrContentEntry, prNumber, pageNumber);
                 var sw = Stopwatch.StartNew();
 
-                // TODO(017): wire progressToken from request _meta once SDK injection is confirmed
-                object? progressToken = null;
-                await _progressReporter.ReportAsync(progressToken, 0, 4,
+                // SDK injects IProgress<T> automatically from _meta.progressToken;
+                // it no-ops when the client omits the token.
+                await _progressReporter.ReportAsync(progress, 0, 4,
                     $"Starting content retrieval for PR #{prNumber}", cancellationToken);
 
                 var budget = _budgetResolver.Resolve(maxTokens, modelName);
@@ -122,7 +123,7 @@ namespace REBUSS.Pure.Tools
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 linkedCts.CancelAfter(_workflowOptions.Value.ContentInternalTimeoutMs);
 
-                await _progressReporter.ReportAsync(progressToken, 1, 4,
+                await _progressReporter.ReportAsync(progress, 1, 4,
                     $"Waiting for enrichment — PR #{prNumber}", cancellationToken);
 
                 PrEnrichmentResult result;
@@ -141,7 +142,7 @@ namespace REBUSS.Pure.Tools
                 // Feature 013 branch: if Copilot is available + enabled, the server performs
                 // the review itself and returns compact page summaries in a single response.
                 // Otherwise, fall through to the existing content-only path.
-                await _progressReporter.ReportAsync(progressToken, 2, 4,
+                await _progressReporter.ReportAsync(progress, 2, 4,
                     $"Enrichment complete — checking review mode", cancellationToken);
 
                 var copilotAvailable = await _copilotAvailability.IsAvailableAsync(cancellationToken);
@@ -178,7 +179,7 @@ namespace REBUSS.Pure.Tools
 
                 sw.Stop();
 
-                await _progressReporter.ReportAsync(progressToken, 4, 4,
+                await _progressReporter.ReportAsync(progress, 4, 4,
                     $"Content ready — page {pageNumber}/{allocation.TotalPages}", cancellationToken);
 
                 _logger.LogInformation(Resources.LogGetPrContentCompleted,

--- a/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
+++ b/REBUSS.Pure/Tools/GetPullRequestMetadataToolHandler.cs
@@ -80,6 +80,7 @@ namespace REBUSS.Pure.Tools
             [Description("The Pull Request number/ID to retrieve metadata for")] int? prNumber = null,
             [Description("Model name for context budget resolution (e.g. 'gpt-4o'). Triggers pagination info.")] string? modelName = null,
             [Description("Explicit token budget override. Triggers pagination info.")] int? maxTokens = null,
+            IProgress<ProgressNotificationValue>? progress = null,
             CancellationToken cancellationToken = default)
         {
             if (prNumber != null && prNumber <= 0)
@@ -93,9 +94,9 @@ namespace REBUSS.Pure.Tools
                 _logger.LogInformation(Resources.LogGetPrMetadataEntry, prNumber);
                 var sw = Stopwatch.StartNew();
 
-                // TODO(017): wire progressToken from request _meta once SDK injection is confirmed
-                object? progressToken = null;
-                await _progressReporter.ReportAsync(progressToken, 0, 3,
+                // SDK injects IProgress<T> automatically from _meta.progressToken;
+                // it no-ops when the client omits the token.
+                await _progressReporter.ReportAsync(progress, 0, 3,
                     $"Fetching PR #{prNumber} metadata", cancellationToken);
 
                 var metadata = await _metadataProvider.GetMetadataAsync(prNumber.Value, cancellationToken);
@@ -113,7 +114,7 @@ namespace REBUSS.Pure.Tools
                 if (_copilotReviewOptions.Value.Enabled)
                     _ = _copilotClientProvider.TryEnsureStartedAsync(CancellationToken.None);
 
-                await _progressReporter.ReportAsync(progressToken, 1, 3,
+                await _progressReporter.ReportAsync(progress, 1, 3,
                     $"PR #{prNumber} metadata retrieved", cancellationToken);
 
                 (int TotalPages, int TotalFiles, int BudgetPerPage, IReadOnlyList<(int Page, int Count)> ByPage)? paging = null;
@@ -133,7 +134,7 @@ namespace REBUSS.Pure.Tools
                 var text = PlainTextFormatter.FormatMetadata(metadata, prNumber.Value, paging, pagingDeferred);
                 sw.Stop();
 
-                await _progressReporter.ReportAsync(progressToken, 3, 3,
+                await _progressReporter.ReportAsync(progress, 3, 3,
                     $"PR #{prNumber} metadata complete", cancellationToken);
 
                 _logger.LogInformation(Resources.LogGetPrMetadataCompleted, prNumber, text.Length, sw.ElapsedMilliseconds);


### PR DESCRIPTION
- Progress reporting now prefers SDK-injected IProgress<T>, with legacy ProgressToken as fallback; updated docs and logging.
- Tool handlers now accept and use IProgress<ProgressNotificationValue> for progress, removing old progressToken plumbing.
- Added/updated tests to verify correct progress dispatch and logging.
- Fixed IndexOutOfRange in DiffParser when context exceeds source lines; added regression test.
- Added static cache for PR file lists in GitHubApiClient to reduce redundant API calls.
- Improved comments and documentation throughout for clarity.