### PR TITLE
Add finding validation pipeline to reduce Copilot false positives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # REBUSS.Pure Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-12
+Auto-generated from all feature plans. Last updated: 2026-04-13
 
 ## Active Technologies
 - C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`) (014-log-noise-reduction)

--- a/REBUSS.Pure.RoslynProcessor.Tests/DiffParserTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/DiffParserTests.cs
@@ -74,11 +74,49 @@ public class DiffParserTests
 
         var result = DiffParser.RebuildDiffWithContext(diff, sourceLines, hunks, ContextDecision.Minimal);
 
-        // Should contain context lines (space-prefixed)
-        Assert.Contains(" line", result);
+        // Should contain enricher-added context lines (feature 021: "[ctx] " prefix).
+        Assert.Contains("[ctx] line", result);
         // Should contain the original change
         Assert.Contains("-old", result);
         Assert.Contains("+new", result);
+    }
+
+    [Fact]
+    public void RebuildDiffWithContext_EnricherAddedContext_UsesCtxPrefix()
+    {
+        // Feature 021: enricher-added context lines must be prefixed with "[ctx] "
+        // so the Copilot reviewer can distinguish them from original unified-diff
+        // context lines (space-prefixed). This reduces false positives from
+        // cross-referencing context against changed lines.
+        var diff = "=== src/A.cs (edit: +1 -1) ===\n@@ -10,1 +10,1 @@\n-old\n+new";
+        var sourceLines = Enumerable.Range(1, 20).Select(i => $"line{i}").ToArray();
+        var hunks = DiffParser.ParseHunks(diff);
+
+        var result = DiffParser.RebuildDiffWithContext(diff, sourceLines, hunks, ContextDecision.Minimal);
+
+        // Leading context present, [ctx]-prefixed.
+        Assert.Contains("[ctx] line7", result);
+        Assert.Contains("[ctx] line8", result);
+        Assert.Contains("[ctx] line9", result);
+        // Trailing context present, [ctx]-prefixed.
+        Assert.Contains("[ctx] line11", result);
+    }
+
+    [Fact]
+    public void RebuildDiffWithContext_InterHunkGapContext_UsesCtxPrefix()
+    {
+        // Adjacent hunks merge — the gap between them is filled with inter-hunk
+        // context, which must also carry the "[ctx] " prefix.
+        var diff = "=== src/A.cs (edit: +2 -2) ===\n" +
+                   "@@ -10,1 +10,1 @@\n-old1\n+new1\n" +
+                   "@@ -15,1 +15,1 @@\n-old2\n+new2";
+        var sourceLines = Enumerable.Range(1, 50).Select(i => $"line{i}").ToArray();
+        var hunks = DiffParser.ParseHunks(diff);
+
+        var result = DiffParser.RebuildDiffWithContext(diff, sourceLines, hunks, ContextDecision.Full);
+
+        // line12 sits in the gap between hunks and must be [ctx]-prefixed.
+        Assert.Contains("[ctx] line12", result);
     }
 
     // ─── Feature 011 — fix duplicated/overlapping hunks + negative line numbers ──────────────
@@ -139,7 +177,8 @@ public class DiffParserTests
 
         // Source line "line12" sits between the two hunks. It must appear EXACTLY ONCE in output
         // (used to appear twice — once as trailing context of hunk 1, once as leading context of hunk 2).
-        var line12Count = result.Split('\n').Count(l => l.TrimEnd('\r') == " line12");
+        // Feature 021: enricher-added context uses "[ctx] " prefix.
+        var line12Count = result.Split('\n').Count(l => l.TrimEnd('\r') == "[ctx] line12");
         Assert.Equal(1, line12Count);
     }
 

--- a/REBUSS.Pure.RoslynProcessor.Tests/EnricherCorpusTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/EnricherCorpusTests.cs
@@ -232,7 +232,9 @@ class Usings
     void M() { }
 }",
             "=== src/Usings.cs (edit: +1 -0) ===\n@@ -3,0 +4,1 @@\n+using System.Text.Json;",
-            5.5  // Tiny baseline + dependency-changes block ⇒ ratio dominated by overhead
+            6.0  // Tiny baseline + dependency-changes block ⇒ ratio dominated by overhead.
+                 // Feature 021 bump: "[ctx] " prefix adds ~4 bytes per context line (+40B
+                 // across 10 Full-context lines), which matters on a 76-byte baseline.
         };
 
         // ── Fixture 5: rename-only (zero hunks) — must pass through unchanged ──

--- a/REBUSS.Pure.RoslynProcessor.Tests/FileStructureValidationEnricherTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/FileStructureValidationEnricherTests.cs
@@ -129,6 +129,23 @@ public class FileStructureValidationEnricherTests : IDisposable
     }
 
     [Fact]
+    public void FormatAnnotation_BothNull_EmitsUnknown()
+    {
+        // Feature 021: nullable inputs produce `unknown` status. Callers emit this
+        // when source is unavailable so the annotation is still present — the
+        // reviewer prompt treats `unknown` as "assume structurally valid".
+        var annotation = FileStructureValidationEnricher.FormatAnnotation(null, null);
+        Assert.Equal("[file-structure: compiles=unknown, balanced-braces=unknown]\n", annotation);
+    }
+
+    [Fact]
+    public void FormatAnnotation_MixedNullAndBool_FormatsCorrectly()
+    {
+        var annotation = FileStructureValidationEnricher.FormatAnnotation(true, null);
+        Assert.Equal("[file-structure: compiles=yes, balanced-braces=unknown]\n", annotation);
+    }
+
+    [Fact]
     public async Task EnrichAsync_ValidFile_InsertsAnnotationAfterHeader()
     {
         var wrapperDir = Path.Combine(_tempDir, "repo");
@@ -169,12 +186,18 @@ public class FileStructureValidationEnricherTests : IDisposable
     }
 
     [Fact]
-    public async Task EnrichAsync_ResolverReturnsNull_ReturnsDiffUnchanged()
+    public async Task EnrichAsync_ResolverReturnsNull_EmitsUnknownAnnotation()
     {
+        // Feature 021: when source is unavailable, the enricher must still emit an
+        // annotation (with `unknown` values) rather than returning the diff unchanged.
+        // Otherwise, a missing annotation is interpreted by the reviewer as "file may
+        // be broken", producing structural false positives.
         _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns((string?)null);
 
         var diff = "=== src/Missing.cs (edit: +1 -1) ===\n@@ -1,1 +1,1 @@\n-old\n+new";
         var result = await _enricher.EnrichAsync(diff);
-        Assert.Equal(diff, result);
+
+        Assert.NotEqual(diff, result);
+        Assert.Contains("[file-structure: compiles=unknown, balanced-braces=unknown]", result);
     }
 }

--- a/REBUSS.Pure.RoslynProcessor.Tests/FindingScopeExtractorTests.cs
+++ b/REBUSS.Pure.RoslynProcessor.Tests/FindingScopeExtractorTests.cs
@@ -1,0 +1,196 @@
+using REBUSS.Pure.RoslynProcessor;
+
+namespace REBUSS.Pure.RoslynProcessor.Tests;
+
+/// <summary>
+/// Tests for <see cref="FindingScopeExtractor"/>. Feature 021.
+/// </summary>
+public class FindingScopeExtractorTests
+{
+    [Fact]
+    public void ExtractScopeBody_MethodLine_ReturnsMethodBody()
+    {
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                public int Bar(int x)
+                {
+                    var y = x + 1;
+                    return y;
+                }
+            }
+            """;
+        // Line 6 = "var y = x + 1;"
+        var (body, name, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 6, 100);
+
+        Assert.True(resolved);
+        Assert.Contains("public int Bar", body);
+        Assert.Contains("var y = x + 1;", body);
+        Assert.Contains("Bar", name);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_ConstructorLine_ReturnsConstructor()
+    {
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                public Foo(int x)
+                {
+                    Value = x;
+                }
+                public int Value { get; }
+            }
+            """;
+        // Line 6 = "Value = x;"
+        var (body, name, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 6, 100);
+
+        Assert.True(resolved);
+        Assert.Contains("public Foo(int x)", body);
+        Assert.Contains("ctor", name);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_PropertyLine_ReturnsProperty()
+    {
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                public int Value { get; set; }
+            }
+            """;
+        // Line 4 = property declaration
+        var (_, name, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 4, 100);
+
+        Assert.True(resolved);
+        Assert.Contains("Value", name);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_ClassLevelField_ReturnsEnclosingClass()
+    {
+        // A class-level field has the enclosing type as its "scope" — the field line
+        // resolves to the class declaration body (FindEnclosingMember walks up to
+        // TypeDeclarationSyntax when no member matches).
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                private readonly int _x = 0;
+                public int Bar() => _x;
+            }
+            """;
+        // Line 4 = field declaration
+        var (body, name, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 4, 100);
+
+        Assert.True(resolved);
+        // Scope name should be the class Foo since the field has no enclosing member.
+        Assert.Equal("Foo", name);
+        Assert.Contains("class Foo", body);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_EmptySource_ReturnsNotResolved()
+    {
+        var (body, name, resolved) = FindingScopeExtractor.ExtractScopeBody("", 1, 100);
+
+        Assert.False(resolved);
+        Assert.Equal("", body);
+        Assert.Equal("", name);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_LineOutOfRange_ReturnsNotResolved()
+    {
+        var code = "namespace Test;\npublic class Foo { }\n";
+        var (_, _, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 100, 100);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_LargeMethodBody_TruncatesAroundLine()
+    {
+        // Build a method with ~200 lines of body.
+        var lines = new List<string>
+        {
+            "namespace Test;",
+            "public class Foo",
+            "{",
+            "    public void Bar()",
+            "    {",
+        };
+        for (var i = 0; i < 200; i++)
+            lines.Add($"        var x{i} = {i};");
+        lines.Add("    }");
+        lines.Add("}");
+        var code = string.Join("\n", lines);
+
+        // Finding at line 100 (middle of the method). maxLines=50.
+        var (body, _, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 100, 50);
+
+        Assert.True(resolved);
+        var bodyLines = body.Split('\n');
+        // Should be roughly bounded: 50 actual lines + possibly 2 truncation markers.
+        Assert.True(bodyLines.Length <= 55, $"Expected <=55 lines, got {bodyLines.Length}");
+        // Should contain the centered finding's line content.
+        Assert.Contains("x95", body);
+        // Should contain an omission marker since the body was larger than 50 lines.
+        Assert.Contains("lines omitted", body);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_BodyUnderLimit_NoTruncationMarker()
+    {
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                public void Bar()
+                {
+                    var x = 1;
+                    var y = 2;
+                    var z = x + y;
+                }
+            }
+            """;
+        var (body, _, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 6, 100);
+
+        Assert.True(resolved);
+        Assert.DoesNotContain("lines omitted", body);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_ZeroMaxLines_ReturnsNotResolved()
+    {
+        var code = "namespace Test;\npublic class Foo { public void Bar() { } }";
+        var (_, _, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 1, 0);
+
+        Assert.False(resolved);
+    }
+
+    [Fact]
+    public void ExtractScopeBody_LineInLocalFunction_ReturnsLocalFunction()
+    {
+        var code = """
+            namespace Test;
+            public class Foo
+            {
+                public void Bar()
+                {
+                    int Inner(int x) { return x * 2; }
+                    var r = Inner(3);
+                }
+            }
+            """;
+        // Line 6 = local function declaration. Inner is a LocalFunctionStatementSyntax,
+        // a member kind handled by FindEnclosingMember.
+        var (_, name, resolved) = FindingScopeExtractor.ExtractScopeBody(code, 6, 100);
+
+        Assert.True(resolved);
+        Assert.Contains("Inner", name);
+    }
+}

--- a/REBUSS.Pure.RoslynProcessor/DiffParser.cs
+++ b/REBUSS.Pure.RoslynProcessor/DiffParser.cs
@@ -127,9 +127,13 @@ public static partial class DiffParser
             var lines = new List<string>();
 
             // Leading context — sliced from the AFTER file at NEW-axis start.
+            // Prefix with "[ctx]" (feature 021) so Copilot distinguishes enricher-added
+            // context from original unified-diff context lines (space-prefixed). This
+            // reduces false positives where the model cross-references context against
+            // changed lines.
             int leadStartIdx = Math.Max(0, firstHunk.NewStart - 1 - leadingCount);
             for (int j = 0; j < leadingCount && leadStartIdx + j < sourceLines.Length; j++)
-                lines.Add(" " + sourceLines[leadStartIdx + j]);
+                lines.Add("[ctx] " + sourceLines[leadStartIdx + j]);
 
             for (int hi = 0; hi < cluster.Count; hi++)
             {
@@ -155,13 +159,13 @@ public static partial class DiffParser
                     int gapStart = h.NewStart - 1 + h.NewCount;        // first context line after this hunk
                     int gapEnd = nextH.NewStart - 1;                   // exclusive
                     for (int j = gapStart; j < gapEnd && j < sourceLines.Length; j++)
-                        lines.Add(" " + sourceLines[j]);
+                        lines.Add("[ctx] " + sourceLines[j]);
                 }
             }
 
             // Trailing context after the last hunk in the cluster.
             for (int j = 0; j < trailingCount; j++)
-                lines.Add(" " + sourceLines[afterPos + j]);
+                lines.Add("[ctx] " + sourceLines[afterPos + j]);
 
             expanded.Add(new ExpandedHunk
             {

--- a/REBUSS.Pure.RoslynProcessor/FileStructureValidationEnricher.cs
+++ b/REBUSS.Pure.RoslynProcessor/FileStructureValidationEnricher.cs
@@ -50,7 +50,14 @@ public partial class FileStructureValidationEnricher : IDiffEnricher
 
             var pair = await _sourceResolver.ResolveAsync(diff, ct);
             if (pair == null)
-                return diff;
+            {
+                // Source unavailable (download timeout, file missing, >100KB) — emit
+                // `unknown` rather than omitting the annotation. Feature 021: a missing
+                // annotation was previously interpreted by the reviewer as "file may be
+                // broken", producing structural false positives.
+                var unknownAnnotation = FormatAnnotation(null, null);
+                return InsertAfterHeader(diff, unknownAnnotation);
+            }
 
             var (syntaxValid, balancedBraces) = Validate(pair.AfterCode);
             var annotation = FormatAnnotation(syntaxValid, balancedBraces);
@@ -94,10 +101,14 @@ public partial class FileStructureValidationEnricher : IDiffEnricher
         return (syntaxValid, openBraces == closeBraces);
     }
 
-    public static string FormatAnnotation(bool syntaxValid, bool balancedBraces)
+    /// <summary>
+    /// Formats the <c>[file-structure]</c> annotation. Feature 021: accepts nullable
+    /// inputs so callers can emit <c>unknown</c> when the source is unavailable.
+    /// </summary>
+    public static string FormatAnnotation(bool? syntaxValid, bool? balancedBraces)
     {
-        var compiles = syntaxValid ? "yes" : "no";
-        var braces = balancedBraces ? "yes" : "no";
+        var compiles = syntaxValid switch { true => "yes", false => "no", null => "unknown" };
+        var braces = balancedBraces switch { true => "yes", false => "no", null => "unknown" };
         return $"[file-structure: compiles={compiles}, balanced-braces={braces}]\n";
     }
 

--- a/REBUSS.Pure.RoslynProcessor/FindingScopeExtractor.cs
+++ b/REBUSS.Pure.RoslynProcessor/FindingScopeExtractor.cs
@@ -1,0 +1,88 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace REBUSS.Pure.RoslynProcessor;
+
+/// <summary>
+/// Extracts the full source body of the enclosing method, property, constructor, or
+/// type that contains a given line number. Reuses <see cref="ScopeResolver.FindEnclosingMember"/>
+/// and <see cref="ScopeResolver.Resolve"/> to keep the walk logic and formatted name in sync.
+/// Feature 021: used by <c>FindingScopeResolver</c> to produce validation input.
+/// </summary>
+public static class FindingScopeExtractor
+{
+    /// <summary>
+    /// Attempts to extract the enclosing scope body for <paramref name="lineNumber"/> (1-based).
+    /// Truncates the body to at most <paramref name="maxLines"/> lines centered on the finding line.
+    /// </summary>
+    /// <returns>
+    /// <c>(ScopeBody, ScopeName, Resolved=true)</c> when a scope is found.
+    /// <c>("", "", Resolved=false)</c> when the syntax tree is empty, the line is out of range,
+    /// or no enclosing member can be located (e.g., top-level statement, class-level field
+    /// with no containing method).
+    /// </returns>
+    public static (string ScopeBody, string ScopeName, bool Resolved) ExtractScopeBody(
+        string sourceCode,
+        int lineNumber,
+        int maxLines)
+    {
+        if (string.IsNullOrEmpty(sourceCode) || lineNumber < 1 || maxLines <= 0)
+            return ("", "", false);
+
+        var tree = CSharpSyntaxTree.ParseText(sourceCode);
+        var root = tree.GetRoot();
+        var text = root.SyntaxTree.GetText();
+
+        if (lineNumber > text.Lines.Count)
+            return ("", "", false);
+
+        var lineSpan = text.Lines[lineNumber - 1].Span;
+        var node = root.FindNode(lineSpan, getInnermostNodeForTie: true);
+        if (node == null)
+            return ("", "", false);
+
+        var enclosing = ScopeResolver.FindEnclosingMember(node);
+        if (enclosing == null)
+            return ("", "", false);
+
+        var scopeName = ScopeResolver.Resolve(root, lineNumber) ?? "";
+        var scopeBody = enclosing.ToFullString();
+        var truncated = TruncateAroundLine(scopeBody, enclosing, lineNumber, text, maxLines);
+
+        return (truncated, scopeName, true);
+    }
+
+    /// <summary>
+    /// If the scope body exceeds <paramref name="maxLines"/>, returns a window of
+    /// <paramref name="maxLines"/> lines centered on the finding's line (converted to a
+    /// line offset within the scope). Otherwise returns the body unchanged.
+    /// </summary>
+    private static string TruncateAroundLine(
+        string scopeBody,
+        SyntaxNode enclosing,
+        int findingLine,
+        Microsoft.CodeAnalysis.Text.SourceText sourceText,
+        int maxLines)
+    {
+        var bodyLines = scopeBody.Replace("\r\n", "\n").Split('\n');
+        if (bodyLines.Length <= maxLines)
+            return scopeBody;
+
+        // Map the absolute finding line (1-based in full source) to a 0-based offset
+        // within the extracted scope body.
+        var scopeStartLine = sourceText.Lines.GetLinePosition(enclosing.SpanStart).Line; // 0-based
+        var findingLineZeroBased = findingLine - 1;
+        var offsetInScope = Math.Max(0, Math.Min(bodyLines.Length - 1, findingLineZeroBased - scopeStartLine));
+
+        var half = maxLines / 2;
+        var start = Math.Max(0, offsetInScope - half);
+        var end = Math.Min(bodyLines.Length, start + maxLines);
+        // Pull start back if end hit the upper bound.
+        start = Math.Max(0, end - maxLines);
+
+        var window = bodyLines[start..end];
+        var prefix = start > 0 ? $"// ... ({start} lines omitted) ...\n" : "";
+        var suffix = end < bodyLines.Length ? $"\n// ... ({bodyLines.Length - end} lines omitted) ..." : "";
+        return prefix + string.Join("\n", window) + suffix;
+    }
+}

--- a/REBUSS.Pure.RoslynProcessor/ScopeResolver.cs
+++ b/REBUSS.Pure.RoslynProcessor/ScopeResolver.cs
@@ -33,7 +33,12 @@ public static class ScopeResolver
         return FormatScope(enclosing);
     }
 
-    private static SyntaxNode? FindEnclosingMember(SyntaxNode node)
+    /// <summary>
+    /// Walks the parent chain to find the innermost enclosing member (method, property,
+    /// constructor, type, namespace, etc.) for the given node. <c>internal</c> so
+    /// <c>FindingScopeExtractor</c> (feature 021) can reuse the walk.
+    /// </summary>
+    internal static SyntaxNode? FindEnclosingMember(SyntaxNode node)
     {
         var current = node;
         while (current != null)

--- a/REBUSS.Pure.Tests/Services/CopilotReview/CopilotReviewOrchestratorTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/CopilotReviewOrchestratorTests.cs
@@ -32,6 +32,9 @@ public class CopilotReviewOrchestratorTests
             Options.Create(new CopilotReviewOptions { ReviewBudgetTokens = budget }),
             lifetime,
             NullLogger<CopilotReviewOrchestrator>.Instance);
+        // Note: FindingValidator and FindingScopeResolver are left at null — tests
+        // operate in opt-out mode (feature 021 US4). The orchestrator must produce
+        // unchanged review text when either dependency is null.
     }
 
     /// <summary>Default allocator: echoes its input into a single page.</summary>
@@ -339,5 +342,30 @@ public class CopilotReviewOrchestratorTests
         var sequentialMinMs = pageCount * pageDelayMs;
         Assert.True(sw.ElapsedMilliseconds < sequentialMinMs,
             $"Expected parallel execution under {sequentialMinMs}ms, but took {sw.ElapsedMilliseconds}ms");
+    }
+
+    // ─── Feature 021 — Finding validation integration (T028, T040) ────────────────
+
+    [Fact]
+    public async Task TriggerReview_NullValidator_ReviewTextUnchanged()
+    {
+        // When FindingValidator is null (opt-out path — spec US4), the orchestrator
+        // must return the original review text without appending a validation footer.
+        var reviewer = Substitute.For<ICopilotPageReviewer>();
+        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(
+                ci.Arg<int>(),
+                "**[critical]** `src/A.cs` (line 5): untouched finding",
+                1)));
+
+        // Create() passes null for validator/resolver.
+        var orchestrator = Create(reviewer, BuildAllocator(numberOfPages: 1));
+        orchestrator.TriggerReview("pr:42", BuildEnrichment(fileCount: 2));
+        var result = await orchestrator.WaitForReviewAsync("pr:42", CancellationToken.None);
+
+        var reviewText = result.PageReviews[0].ReviewText;
+        Assert.Contains("untouched finding", reviewText);
+        // Feature 021: no validation footer when validator is null.
+        Assert.DoesNotContain("_Validation:", reviewText);
     }
 }

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingFiltererTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingFiltererTests.cs
@@ -1,0 +1,137 @@
+using REBUSS.Pure.Services.CopilotReview.Validation;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Validation;
+
+/// <summary>Unit tests for <see cref="FindingFilterer"/>. Feature 021.</summary>
+public class FindingFiltererTests
+{
+    private static ParsedFinding MakeFinding(int idx, string text) => new()
+    {
+        Index = idx,
+        FilePath = "src/A.cs",
+        LineNumber = 10,
+        Severity = "major",
+        Description = $"issue {idx}",
+        OriginalText = text,
+    };
+
+    [Fact]
+    public void Apply_AllValid_KeepsAllFindingsAndAppendsSummary()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "finding A"), Verdict = FindingVerdict.Valid },
+            new ValidatedFinding { Finding = MakeFinding(1, "finding B"), Verdict = FindingVerdict.Valid },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        Assert.Contains("finding A", result);
+        Assert.Contains("finding B", result);
+        Assert.Contains("_Validation: 2 confirmed, 0 filtered, 0 uncertain_", result);
+    }
+
+    [Fact]
+    public void Apply_RemovesFalsePositives()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "real bug"), Verdict = FindingVerdict.Valid },
+            new ValidatedFinding { Finding = MakeFinding(1, "fake bug"), Verdict = FindingVerdict.FalsePositive },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        Assert.Contains("real bug", result);
+        Assert.DoesNotContain("fake bug", result);
+        Assert.Contains("1 confirmed, 1 filtered, 0 uncertain", result);
+    }
+
+    [Fact]
+    public void Apply_TagsUncertainWithPrefix()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "needs review"), Verdict = FindingVerdict.Uncertain },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        Assert.Contains("[uncertain] needs review", result);
+        Assert.Contains("0 confirmed, 0 filtered, 1 uncertain", result);
+    }
+
+    [Fact]
+    public void Apply_AllFilteredNoRemainder_ReturnsNoIssuesFound()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "fake 1"), Verdict = FindingVerdict.FalsePositive },
+            new ValidatedFinding { Finding = MakeFinding(1, "fake 2"), Verdict = FindingVerdict.FalsePositive },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        Assert.Contains("No issues found.", result);
+        // Summary still shows even when everything was filtered.
+        Assert.Contains("0 confirmed, 2 filtered, 0 uncertain", result);
+    }
+
+    [Fact]
+    public void Apply_UnparseableRemainderPreservedVerbatim()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "real bug"), Verdict = FindingVerdict.Valid },
+        };
+
+        var result = FindingFilterer.Apply("## Critical Issues\nIntro prose.\n", validated);
+
+        Assert.Contains("## Critical Issues", result);
+        Assert.Contains("Intro prose.", result);
+        Assert.Contains("real bug", result);
+    }
+
+    [Fact]
+    public void Apply_NoFindings_NoFooterAppended()
+    {
+        var result = FindingFilterer.Apply("Some review text.", Array.Empty<ValidatedFinding>());
+
+        // SC-005: no footer when there are zero parseable findings.
+        Assert.DoesNotContain("_Validation:", result);
+        Assert.Contains("Some review text.", result);
+    }
+
+    [Fact]
+    public void Apply_MixedVerdicts_CountsAreCorrect()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "a"), Verdict = FindingVerdict.Valid },
+            new ValidatedFinding { Finding = MakeFinding(1, "b"), Verdict = FindingVerdict.Valid },
+            new ValidatedFinding { Finding = MakeFinding(2, "c"), Verdict = FindingVerdict.Valid },
+            new ValidatedFinding { Finding = MakeFinding(3, "d"), Verdict = FindingVerdict.FalsePositive },
+            new ValidatedFinding { Finding = MakeFinding(4, "e"), Verdict = FindingVerdict.FalsePositive },
+            new ValidatedFinding { Finding = MakeFinding(5, "f"), Verdict = FindingVerdict.Uncertain },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        Assert.Contains("_Validation: 3 confirmed, 2 filtered, 1 uncertain_", result);
+    }
+
+    [Fact]
+    public void Apply_FooterHasExpectedFormat()
+    {
+        var validated = new[]
+        {
+            new ValidatedFinding { Finding = MakeFinding(0, "a"), Verdict = FindingVerdict.Valid },
+        };
+
+        var result = FindingFilterer.Apply("", validated);
+
+        // Exact format check (italic markdown underscores + separator).
+        Assert.Contains("---", result);
+        Assert.EndsWith("_Validation: 1 confirmed, 0 filtered, 0 uncertain_", result);
+    }
+}

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingParserTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingParserTests.cs
@@ -1,0 +1,140 @@
+using REBUSS.Pure.Services.CopilotReview.Validation;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Validation;
+
+/// <summary>Unit tests for <see cref="FindingParser"/>. Feature 021.</summary>
+public class FindingParserTests
+{
+    [Fact]
+    public void Parse_SingleWellFormedFinding_ExtractsAllFields()
+    {
+        var input = "**[critical]** `src/Foo.cs` (line 42): Null dereference on empty input";
+
+        var (findings, remainder) = FindingParser.Parse(input);
+
+        var f = Assert.Single(findings);
+        Assert.Equal(0, f.Index);
+        Assert.Equal("src/Foo.cs", f.FilePath);
+        Assert.Equal(42, f.LineNumber);
+        Assert.Equal("critical", f.Severity);
+        Assert.Equal("Null dereference on empty input", f.Description);
+        Assert.Equal("", remainder.Trim());
+    }
+
+    [Fact]
+    public void Parse_FindingWithoutLine_LineNumberIsNull()
+    {
+        var input = "**[major]** `src/Foo.cs`: Async method lacks await";
+
+        var (findings, _) = FindingParser.Parse(input);
+
+        var f = Assert.Single(findings);
+        Assert.Null(f.LineNumber);
+        Assert.Equal("major", f.Severity);
+    }
+
+    [Fact]
+    public void Parse_MixedSeverities_ParsesAllInOrder()
+    {
+        var input = """
+            **[critical]** `src/A.cs` (line 1): issue one
+            **[major]** `src/B.cs` (line 2): issue two
+            **[minor]** `src/C.cs` (line 3): issue three
+            """;
+
+        var (findings, _) = FindingParser.Parse(input);
+
+        Assert.Equal(3, findings.Count);
+        Assert.Equal("critical", findings[0].Severity);
+        Assert.Equal("major", findings[1].Severity);
+        Assert.Equal("minor", findings[2].Severity);
+        Assert.Equal(0, findings[0].Index);
+        Assert.Equal(1, findings[1].Index);
+        Assert.Equal(2, findings[2].Index);
+    }
+
+    [Fact]
+    public void Parse_UnparseableText_ReturnsEmptyFindingsAndFullRemainder()
+    {
+        var input = "No issues found.\nEverything looks good.";
+
+        var (findings, remainder) = FindingParser.Parse(input);
+
+        Assert.Empty(findings);
+        Assert.Equal(input, remainder);
+    }
+
+    [Fact]
+    public void Parse_PartiallyParseable_ReturnsMixedOutput()
+    {
+        var input = """
+            ## Critical Issues
+
+            **[critical]** `src/A.cs` (line 5): null deref
+            Some trailing prose after the finding.
+            """;
+
+        var (findings, remainder) = FindingParser.Parse(input);
+
+        Assert.Single(findings);
+        Assert.Equal("src/A.cs", findings[0].FilePath);
+        // Remainder contains the heading (before the finding) and trailing prose (after).
+        Assert.Contains("## Critical Issues", remainder);
+        Assert.Contains("trailing prose", remainder);
+        // Remainder does NOT contain the finding line itself.
+        Assert.DoesNotContain("null deref", remainder);
+    }
+
+    [Fact]
+    public void Parse_EmptyInput_ReturnsEmpty()
+    {
+        var (findings, remainder) = FindingParser.Parse("");
+
+        Assert.Empty(findings);
+        Assert.Equal("", remainder);
+    }
+
+    [Fact]
+    public void Parse_WhitespaceOnly_ReturnsEmpty()
+    {
+        var (findings, remainder) = FindingParser.Parse("   \n\t  \n");
+
+        Assert.Empty(findings);
+        Assert.Equal("   \n\t  \n", remainder);
+    }
+
+    [Fact]
+    public void Parse_FindingWithBackticksInDescription_ParsesCorrectly()
+    {
+        var input = "**[minor]** `src/Foo.cs` (line 3): Consider using `nameof(X)` instead";
+
+        var (findings, _) = FindingParser.Parse(input);
+
+        var f = Assert.Single(findings);
+        Assert.Contains("nameof", f.Description);
+    }
+
+    [Fact]
+    public void Parse_SeverityCaseInsensitive_Normalized()
+    {
+        var input = "**[CRITICAL]** `src/Foo.cs` (line 1): upper-case severity";
+
+        var (findings, _) = FindingParser.Parse(input);
+
+        var f = Assert.Single(findings);
+        Assert.Equal("critical", f.Severity); // normalized to lowercase
+    }
+
+    [Fact]
+    public void Parse_OriginalTextCapturesEntireHeaderLine()
+    {
+        var input = "**[critical]** `src/Foo.cs` (line 42): Null dereference";
+
+        var (findings, _) = FindingParser.Parse(input);
+
+        var f = Assert.Single(findings);
+        Assert.Contains("[critical]", f.OriginalText);
+        Assert.Contains("src/Foo.cs", f.OriginalText);
+        Assert.Contains("Null dereference", f.OriginalText);
+    }
+}

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingScopeResolverTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingScopeResolverTests.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using REBUSS.Pure.Core;
+using REBUSS.Pure.RoslynProcessor;
+using REBUSS.Pure.Services.CopilotReview.Validation;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Validation;
+
+/// <summary>Unit tests for <see cref="FindingScopeResolver"/>. Feature 021.</summary>
+public class FindingScopeResolverTests : IDisposable
+{
+    private readonly IRepositoryDownloadOrchestrator _orchestrator = Substitute.For<IRepositoryDownloadOrchestrator>();
+    private readonly DiffSourceResolver _sourceResolver;
+    private readonly FindingScopeResolver _resolver;
+    private readonly string _tempDir;
+
+    public FindingScopeResolverTests()
+    {
+        _sourceResolver = new DiffSourceResolver(_orchestrator, NullLogger<DiffSourceResolver>.Instance);
+        _resolver = new FindingScopeResolver(_sourceResolver, NullLogger<FindingScopeResolver>.Instance);
+        _tempDir = Path.Combine(Path.GetTempPath(), $"finding-scope-resolver-test-{Guid.NewGuid():N}");
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private static ParsedFinding MakeFinding(string filePath, int? line = null) => new()
+    {
+        Index = 0,
+        FilePath = filePath,
+        LineNumber = line,
+        Severity = "major",
+        Description = "test",
+        OriginalText = "test",
+    };
+
+    [Fact]
+    public async Task ResolveAsync_EmptyInput_ReturnsEmpty()
+    {
+        var result = await _resolver.ResolveAsync(
+            Array.Empty<ParsedFinding>(), 150, CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NonCSharpFile_ReturnsNotCSharp()
+    {
+        var findings = new[]
+        {
+            MakeFinding("src/config.json", 5),
+            MakeFinding("docs/README.md", 10),
+            MakeFinding("src/app.ts", 15),
+        };
+
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        Assert.All(result, r => Assert.Equal(ScopeResolutionFailure.NotCSharp, r.ResolutionFailure));
+        Assert.All(result, r => Assert.Equal("", r.ScopeSource));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SourceUnavailable_ReturnsSourceUnavailable()
+    {
+        // orchestrator returns null => DiffSourceResolver returns null pair => SourceUnavailable.
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns((string?)null);
+
+        var findings = new[] { MakeFinding("src/Missing.cs", 5) };
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        var r = Assert.Single(result);
+        Assert.Equal(ScopeResolutionFailure.SourceUnavailable, r.ResolutionFailure);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ScopeNotFound_WhenLineNumberMissing()
+    {
+        // Arrange: file source is available, but the finding has no line number.
+        SetupFileSource("Foo.cs", """
+            namespace Test;
+            public class Foo
+            {
+                public void Bar() { }
+            }
+            """);
+
+        var findings = new[] { MakeFinding("Foo.cs", line: null) };
+
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        var r = Assert.Single(result);
+        Assert.Equal(ScopeResolutionFailure.ScopeNotFound, r.ResolutionFailure);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ValidCSharpFile_ReturnsNoneWithScope()
+    {
+        SetupFileSource("Foo.cs", """
+            namespace Test;
+            public class Foo
+            {
+                public void Bar()
+                {
+                    var x = 1;
+                }
+            }
+            """);
+
+        // Line 6 = "var x = 1;" inside Bar().
+        var findings = new[] { MakeFinding("Foo.cs", line: 6) };
+
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        var r = Assert.Single(result);
+        Assert.Equal(ScopeResolutionFailure.None, r.ResolutionFailure);
+        Assert.Contains("Bar", r.ScopeName);
+        Assert.Contains("var x = 1;", r.ScopeSource);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_GroupsByFilePath_SingleSourceResolutionPerFile()
+    {
+        SetupFileSource("Foo.cs", """
+            namespace Test;
+            public class Foo
+            {
+                public void A() { }
+                public void B() { }
+                public void C() { }
+            }
+            """);
+
+        var findings = new[]
+        {
+            MakeFinding("Foo.cs", line: 4),
+            MakeFinding("Foo.cs", line: 5),
+            MakeFinding("Foo.cs", line: 6),
+        };
+
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result, r => Assert.Equal(ScopeResolutionFailure.None, r.ResolutionFailure));
+        // Each finding resolves to its own enclosing method.
+        var names = result.Select(r => r.ScopeName).ToHashSet();
+        Assert.Equal(3, names.Count);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MixedFailures_EachMappedCorrectly()
+    {
+        SetupFileSource("Foo.cs", """
+            namespace Test;
+            public class Foo
+            {
+                public void Bar() { var x = 1; }
+            }
+            """);
+
+        var findings = new[]
+        {
+            MakeFinding("config.json", line: 5),            // NotCSharp
+            MakeFinding("Foo.cs", line: 4),                 // None (method body line)
+            MakeFinding("Foo.cs", line: null),              // ScopeNotFound (no line)
+        };
+
+        var result = await _resolver.ResolveAsync(findings, 150, CancellationToken.None);
+
+        Assert.Equal(ScopeResolutionFailure.NotCSharp, result[0].ResolutionFailure);
+        Assert.Equal(ScopeResolutionFailure.None, result[1].ResolutionFailure);
+        Assert.Equal(ScopeResolutionFailure.ScopeNotFound, result[2].ResolutionFailure);
+    }
+
+    private void SetupFileSource(string relativePath, string content)
+    {
+        var wrapperDir = Path.Combine(_tempDir, "repo");
+        Directory.CreateDirectory(wrapperDir);
+        var fullPath = Path.Combine(wrapperDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+        _orchestrator.GetExtractedPathAsync(Arg.Any<CancellationToken>()).Returns(_tempDir);
+    }
+}

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingValidatorTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Validation/FindingValidatorTests.cs
@@ -1,0 +1,267 @@
+using GitHub.Copilot.SDK;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using REBUSS.Pure.Core.Services.CopilotReview;
+using REBUSS.Pure.Services.CopilotReview;
+using REBUSS.Pure.Services.CopilotReview.Validation;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Validation;
+
+/// <summary>Unit tests for <see cref="FindingValidator"/>. Feature 021.</summary>
+public class FindingValidatorTests
+{
+    private static FindingValidator CreateValidator(FakeSessionFactory factory, int batchSize = 5) =>
+        new(factory,
+            Options.Create(new CopilotReviewOptions
+            {
+                Model = "claude-sonnet-4.6",
+                ValidateFindings = true,
+                ValidationBatchSize = batchSize,
+            }),
+            NullLogger<FindingValidator>.Instance);
+
+    private static ParsedFinding MakeFinding(int index) => new()
+    {
+        Index = index,
+        FilePath = "src/A.cs",
+        LineNumber = 10,
+        Severity = "major",
+        Description = $"issue {index}",
+        OriginalText = $"**[major]** `src/A.cs` (line 10): issue {index}",
+    };
+
+    private static FindingWithScope Resolved(ParsedFinding finding) => new()
+    {
+        Finding = finding,
+        ScopeSource = "public void Bar() { }",
+        ScopeName = "Foo.Bar()",
+        ResolutionFailure = ScopeResolutionFailure.None,
+    };
+
+    private static FindingWithScope Unresolved(ParsedFinding finding, ScopeResolutionFailure failure) => new()
+    {
+        Finding = finding,
+        ScopeSource = "",
+        ScopeName = "",
+        ResolutionFailure = failure,
+    };
+
+    [Fact]
+    public async Task ValidateAsync_NotCSharp_MapsToValidWithoutCopilotCall()
+    {
+        var factory = new FakeSessionFactory { OnSendAsync = (_, _) => throw new Exception("must not call Copilot") };
+
+        var validator = CreateValidator(factory);
+        var input = new[] { Unresolved(MakeFinding(0), ScopeResolutionFailure.NotCSharp) };
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        var v = Assert.Single(result);
+        Assert.Equal(FindingVerdict.Valid, v.Verdict);
+        Assert.Equal(0, factory.CreateSessionCalls);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SourceUnavailable_MapsToUncertainWithoutCopilotCall()
+    {
+        var factory = new FakeSessionFactory { OnSendAsync = (_, _) => throw new Exception("must not call Copilot") };
+
+        var validator = CreateValidator(factory);
+        var input = new[] { Unresolved(MakeFinding(0), ScopeResolutionFailure.SourceUnavailable) };
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        var v = Assert.Single(result);
+        Assert.Equal(FindingVerdict.Uncertain, v.Verdict);
+        Assert.Equal(0, factory.CreateSessionCalls);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ScopeNotFound_MapsToUncertainWithoutCopilotCall()
+    {
+        var factory = new FakeSessionFactory { OnSendAsync = (_, _) => throw new Exception("must not call Copilot") };
+
+        var validator = CreateValidator(factory);
+        var input = new[] { Unresolved(MakeFinding(0), ScopeResolutionFailure.ScopeNotFound) };
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        var v = Assert.Single(result);
+        Assert.Equal(FindingVerdict.Uncertain, v.Verdict);
+        Assert.Equal(0, factory.CreateSessionCalls);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_ResolvedFindings_CallsCopilotAndParsesVerdicts()
+    {
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            h.PushEvent(new AssistantMessageEvent
+            {
+                Data = new AssistantMessageData
+                {
+                    MessageId = "m",
+                    Content =
+                        "**Finding 1: VALID** — this is a real bug\n" +
+                        "**Finding 2: FALSE_POSITIVE** — misinterpreted context\n" +
+                        "**Finding 3: UNCERTAIN** — needs cross-file check",
+                }
+            });
+            h.PushEvent(new SessionIdleEvent { Data = new SessionIdleData() });
+        };
+
+        var validator = CreateValidator(factory);
+        var input = new[]
+        {
+            Resolved(MakeFinding(0)),
+            Resolved(MakeFinding(1)),
+            Resolved(MakeFinding(2)),
+        };
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal(FindingVerdict.Valid, result[0].Verdict);
+        Assert.Equal(FindingVerdict.FalsePositive, result[1].Verdict);
+        Assert.Equal(FindingVerdict.Uncertain, result[2].Verdict);
+        Assert.Equal(1, factory.CreateSessionCalls); // one batch
+    }
+
+    [Fact]
+    public async Task ValidateAsync_TwelveFindings_BatchSizeFive_MakesThreeCalls()
+    {
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            // Response template: declare every finding in the batch VALID.
+            var content = string.Join('\n',
+                Enumerable.Range(1, 10).Select(i => $"**Finding {i}: VALID** — ok"));
+            h.PushEvent(new AssistantMessageEvent { Data = new AssistantMessageData { MessageId = "m", Content = content } });
+            h.PushEvent(new SessionIdleEvent { Data = new SessionIdleData() });
+        };
+
+        var validator = CreateValidator(factory, batchSize: 5);
+        var input = Enumerable.Range(0, 12).Select(i => Resolved(MakeFinding(i))).ToArray();
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        Assert.Equal(12, result.Count);
+        // 12 / 5 = 3 batches (5, 5, 2).
+        Assert.Equal(3, factory.CreateSessionCalls);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_SessionFailure_FindingsPassThroughAsValid()
+    {
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            h.PushEvent(new SessionErrorEvent { Data = new SessionErrorData { ErrorType = "model", Message = "boom" } });
+        };
+
+        var validator = CreateValidator(factory);
+        var input = new[] { Resolved(MakeFinding(0)), Resolved(MakeFinding(1)) };
+
+        var result = await validator.ValidateAsync(input, CancellationToken.None);
+
+        // Graceful degradation: both findings kept as Valid.
+        Assert.All(result, r => Assert.Equal(FindingVerdict.Valid, r.Verdict));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_EmptyInput_NoCopilotCall()
+    {
+        var factory = new FakeSessionFactory();
+
+        var validator = CreateValidator(factory);
+        var result = await validator.ValidateAsync(Array.Empty<FindingWithScope>(), CancellationToken.None);
+
+        Assert.Empty(result);
+        Assert.Equal(0, factory.CreateSessionCalls);
+    }
+
+    [Fact]
+    public async Task ValidateAsync_MixedResolvedAndUnresolved_OnlyResolvedSentToCopilot()
+    {
+        var factory = new FakeSessionFactory();
+        int? capturedFindingsInPrompt = null;
+        factory.OnSendAsync = (h, prompt) =>
+        {
+            // Count how many "## Finding " headers are in the prompt — should equal
+            // the number of RESOLVED findings in this batch.
+            capturedFindingsInPrompt =
+                System.Text.RegularExpressions.Regex.Matches(prompt, @"^## Finding ", System.Text.RegularExpressions.RegexOptions.Multiline).Count;
+            h.PushEvent(new AssistantMessageEvent { Data = new AssistantMessageData { MessageId = "m", Content = "**Finding 1: VALID** ok" } });
+            h.PushEvent(new SessionIdleEvent { Data = new SessionIdleData() });
+        };
+
+        var validator = CreateValidator(factory);
+        var input = new[]
+        {
+            Unresolved(MakeFinding(0), ScopeResolutionFailure.NotCSharp),
+            Resolved(MakeFinding(1)),
+            Unresolved(MakeFinding(2), ScopeResolutionFailure.ScopeNotFound),
+        };
+
+        _ = await validator.ValidateAsync(input, CancellationToken.None);
+
+        Assert.Equal(1, capturedFindingsInPrompt);
+    }
+
+    [Fact]
+    public void CopilotReviewOptions_ValidateFindings_DefaultsToTrue()
+    {
+        var options = new CopilotReviewOptions();
+        Assert.True(options.ValidateFindings);
+    }
+
+    // ─── Fakes (mirror CopilotPageReviewerTests pattern) ────────────────────────
+
+    private sealed class FakeSessionFactory : ICopilotSessionFactory
+    {
+        public Action<FakeSessionHandle, string>? OnSendAsync { get; set; }
+        public int CreateSessionCalls { get; private set; }
+
+        public Task<ICopilotSessionHandle> CreateSessionAsync(string model, CancellationToken ct)
+        {
+            CreateSessionCalls++;
+            FakeSessionHandle? handle = null;
+            handle = new FakeSessionHandle(prompt => OnSendAsync?.Invoke(handle!, prompt));
+            return Task.FromResult<ICopilotSessionHandle>(handle);
+        }
+    }
+
+    private sealed class FakeSessionHandle : ICopilotSessionHandle
+    {
+        private readonly List<Action<object>> _handlers = new();
+        private readonly Action<string> _onSend;
+        public FakeSessionHandle(Action<string> onSend) { _onSend = onSend; }
+
+        public Task<string> SendAsync(string prompt, CancellationToken ct)
+        {
+            _onSend(prompt);
+            return Task.FromResult("msg-id-1");
+        }
+
+        public IDisposable On(Action<object> handler)
+        {
+            _handlers.Add(handler);
+            return new Subscription(() => _handlers.Remove(handler));
+        }
+
+        public void PushEvent(object evt)
+        {
+            foreach (var h in _handlers.ToList()) h(evt);
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        private sealed class Subscription : IDisposable
+        {
+            private readonly Action _onDispose;
+            public Subscription(Action onDispose) { _onDispose = onDispose; }
+            public void Dispose() => _onDispose();
+        }
+    }
+}

--- a/REBUSS.Pure/Program.cs
+++ b/REBUSS.Pure/Program.cs
@@ -186,6 +186,14 @@ namespace REBUSS.Pure
             services.AddSingleton<ICopilotSessionFactory, CopilotSessionFactory>();
             services.AddSingleton<ICopilotAvailabilityDetector, CopilotAvailabilityDetector>();
             services.AddSingleton<ICopilotPageReviewer, CopilotPageReviewer>();
+
+            // Feature 021 — Finding validation pipeline (false positive reduction).
+            // Registered unconditionally; CopilotReviewOrchestrator short-circuits at
+            // runtime based on CopilotReviewOptions.ValidateFindings (per Principle V
+            // deferred resolution — the flag is read at first review, not at DI time).
+            services.AddSingleton<REBUSS.Pure.Services.CopilotReview.Validation.FindingScopeResolver>();
+            services.AddSingleton<REBUSS.Pure.Services.CopilotReview.Validation.FindingValidator>();
+
             services.AddSingleton<ICopilotReviewOrchestrator, CopilotReviewOrchestrator>();
             services.AddSingleton<CopilotReviewWaiter>();
 

--- a/REBUSS.Pure/REBUSS.Pure.csproj
+++ b/REBUSS.Pure/REBUSS.Pure.csproj
@@ -30,6 +30,7 @@
     <EmbeddedResource Include="Cli\Prompts\self-review.prompt.md" />
     <EmbeddedResource Include="Cli\Prompts\create-pr.md" />
     <EmbeddedResource Include="Services\CopilotReview\Prompts\copilot-page-review.md" />
+    <EmbeddedResource Include="Services\CopilotReview\Prompts\copilot-finding-validation.md" />
     <EmbeddedResource Update="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>

--- a/REBUSS.Pure/Services/CopilotReview/CopilotReviewOptions.cs
+++ b/REBUSS.Pure/Services/CopilotReview/CopilotReviewOptions.cs
@@ -61,4 +61,31 @@ public sealed class CopilotReviewOptions
     /// will fail verification.
     /// </summary>
     public const string GitHubTokenEnvironmentVariable = "REBUSS_COPILOT_TOKEN";
+
+    // ─── Feature 021: Finding validation ────────────────────────────────────
+
+    /// <summary>
+    /// When <c>true</c>, each page's findings are re-checked against the full source
+    /// of their enclosing method/scope via a second Copilot call. False positives are
+    /// filtered from the final output. Feature 021 (FR-014).
+    /// </summary>
+    public bool ValidateFindings { get; set; } = true;
+
+    /// <summary>
+    /// Max findings per validation Copilot call. Smaller batches give each finding
+    /// more model attention at the cost of more calls. Feature 021 (FR-009).
+    /// </summary>
+    public int ValidationBatchSize { get; set; } = 5;
+
+    /// <summary>
+    /// If a review page produces more findings than this, validation is skipped for that
+    /// page (likely a systemic issue, not individual false positives). Feature 021 (FR-015).
+    /// </summary>
+    public int MaxValidatableFindings { get; set; } = 40;
+
+    /// <summary>
+    /// Truncate method bodies exceeding this line count, centered on the finding's line.
+    /// Bounds token usage for validation calls. Feature 021 (FR-016).
+    /// </summary>
+    public int MaxScopeLines { get; set; } = 150;
 }

--- a/REBUSS.Pure/Services/CopilotReview/CopilotReviewOrchestrator.cs
+++ b/REBUSS.Pure/Services/CopilotReview/CopilotReviewOrchestrator.cs
@@ -8,6 +8,7 @@ using REBUSS.Pure.Core.Models;
 using REBUSS.Pure.Core.Models.CopilotReview;
 using REBUSS.Pure.Core.Services.CopilotReview;
 using REBUSS.Pure.Properties;
+using REBUSS.Pure.Services.CopilotReview.Validation;
 using REBUSS.Pure.Services.PrEnrichment;
 
 namespace REBUSS.Pure.Services.CopilotReview;
@@ -25,6 +26,11 @@ internal sealed class CopilotReviewOrchestrator : ICopilotReviewOrchestrator
     private readonly ILogger<CopilotReviewOrchestrator> _logger;
     private readonly CancellationToken _shutdownToken;
 
+    // Feature 021: optional finding validator. Null when ValidateFindings == false
+    // (opt-out per spec US4). Also null if DI couldn't resolve it.
+    private readonly FindingValidator? _findingValidator;
+    private readonly FindingScopeResolver? _findingScopeResolver;
+
     private readonly ConcurrentDictionary<string, CopilotReviewJob> _jobs = new();
     private readonly object _lock = new();
 
@@ -33,13 +39,17 @@ internal sealed class CopilotReviewOrchestrator : ICopilotReviewOrchestrator
         IPageAllocator pageAllocator,
         IOptions<CopilotReviewOptions> options,
         IHostApplicationLifetime lifetime,
-        ILogger<CopilotReviewOrchestrator> logger)
+        ILogger<CopilotReviewOrchestrator> logger,
+        FindingValidator? findingValidator = null,
+        FindingScopeResolver? findingScopeResolver = null)
     {
         _pageReviewer = pageReviewer;
         _pageAllocator = pageAllocator;
         _options = options;
         _logger = logger;
         _shutdownToken = lifetime.ApplicationStopping;
+        _findingValidator = findingValidator;
+        _findingScopeResolver = findingScopeResolver;
     }
 
     public void TriggerReview(string reviewKey, IEnrichmentResult enrichmentResult)
@@ -202,8 +212,78 @@ internal sealed class CopilotReviewOrchestrator : ICopilotReviewOrchestrator
         CancellationToken ct)
     {
         var result = await ReviewPageWithRetryAsync(job, pageNumber, enrichedContent, filePathsOnPage, ct);
+
+        // Feature 021: post-review finding validation. Runs only when the review
+        // succeeded, the feature is enabled, and the validator+resolver are wired in DI.
+        if (result.Succeeded
+            && _options.Value.ValidateFindings
+            && _findingValidator is not null
+            && _findingScopeResolver is not null)
+        {
+            try
+            {
+                result = await ValidateAndFilterAsync(job, pageNumber, result, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                // Graceful degradation (FR-012): validation failure must not break the
+                // review — pass the original result through unfiltered.
+                _logger.LogWarning(ex,
+                    "Validation pass failed for '{ReviewKey}' page {PageNumber}; returning original result",
+                    job.ReviewKey, pageNumber);
+            }
+        }
+
         Interlocked.Increment(ref job.CompletedPages);
         return result;
+    }
+
+    /// <summary>
+    /// Parses findings from the review text, resolves each finding's enclosing scope,
+    /// validates them via a second Copilot pass, and rebuilds the result with
+    /// false-positives removed and uncertain findings tagged. Feature 021.
+    /// </summary>
+    private async Task<CopilotPageReviewResult> ValidateAndFilterAsync(
+        CopilotReviewJob job,
+        int pageNumber,
+        CopilotPageReviewResult original,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(original.ReviewText))
+            return original;
+
+        job.CurrentActivity = $"Page {pageNumber}/{job.TotalPages}: parsing findings for validation";
+        var (findings, remainder) = FindingParser.Parse(original.ReviewText!);
+
+        // Zero parseable findings → nothing to validate. Return the original review
+        // text as-is (no summary footer; SC-005 scoping excludes this case).
+        if (findings.Count == 0)
+            return original;
+
+        // Over-threshold → skip validation for this page (FR-015). Likely a systemic
+        // issue; individual validation isn't the right tool.
+        var maxValidatable = _options.Value.MaxValidatableFindings;
+        if (maxValidatable > 0 && findings.Count > maxValidatable)
+        {
+            _logger.LogInformation(
+                "Skipping validation for '{ReviewKey}' page {PageNumber}: {Count} findings exceed MaxValidatableFindings={Max}",
+                job.ReviewKey, pageNumber, findings.Count, maxValidatable);
+            return original;
+        }
+
+        job.CurrentActivity = $"Page {pageNumber}/{job.TotalPages}: resolving {findings.Count} scopes";
+        var withScopes = await _findingScopeResolver!.ResolveAsync(
+            findings, _options.Value.MaxScopeLines, ct).ConfigureAwait(false);
+
+        job.CurrentActivity = $"Page {pageNumber}/{job.TotalPages}: validating {findings.Count} findings";
+        var validated = await _findingValidator!.ValidateAsync(withScopes, ct).ConfigureAwait(false);
+
+        var filteredText = FindingFilterer.Apply(remainder, validated);
+        return CopilotPageReviewResult.Success(pageNumber, filteredText, attemptsMade: original.AttemptsMade);
     }
 
     /// <summary>

--- a/REBUSS.Pure/Services/CopilotReview/Prompts/copilot-finding-validation.md
+++ b/REBUSS.Pure/Services/CopilotReview/Prompts/copilot-finding-validation.md
@@ -1,0 +1,34 @@
+# Finding Validation Task
+
+You are validating code review findings against actual source code. For each finding
+below, the full method/scope source is provided — this is **not** a diff. Every line
+shown is the real, current code.
+
+## Your Task
+
+For each finding, output **exactly one verdict** using this format:
+
+```
+**Finding {N}: {VERDICT}** — reason (one sentence)
+```
+
+Where `{VERDICT}` is one of:
+
+- **VALID** — the issue genuinely exists in the shown source code
+- **FALSE_POSITIVE** — the issue does not exist in the shown source; it was likely
+  caused by the reviewer misinterpreting diff context lines, incomplete code
+  visibility, or cross-file assumptions that cannot be verified from the scope alone
+- **UNCERTAIN** — cannot determine from the provided scope alone (e.g., requires
+  cross-file knowledge not present in the shown source)
+
+## Rules
+
+- Respond with exactly one verdict line per finding, in the order they appear below.
+- Use the exact numbering `Finding 1`, `Finding 2`, etc., matching the headers below.
+- Keep the reason short (≤ 20 words).
+- Do NOT re-describe the issue. Do NOT propose fixes. Just render the verdict.
+- If two findings describe the same issue, still render one verdict per finding.
+
+---
+
+{findingsWithScopes}

--- a/REBUSS.Pure/Services/CopilotReview/Prompts/copilot-page-review.md
+++ b/REBUSS.Pure/Services/CopilotReview/Prompts/copilot-page-review.md
@@ -3,9 +3,24 @@
 You are reviewing a **unified diff** (not a complete file). The diff shows only changed
 lines with a few lines of surrounding context. Unchanged code is NOT shown.
 
+## Context Lines
+
+Lines prefixed with `[ctx]` are **unchanged surrounding context** added by the
+enrichment pipeline. They exist solely to orient you within the file — they are
+NOT part of the change.
+
+**Rules for `[ctx]` lines:**
+
+- Do NOT report issues found only in `[ctx]` lines.
+- Do NOT compare `[ctx]` lines against `+`/`-` lines to find contradictions — they
+  may contain similar patterns (e.g., `Assert.True`) that operate on completely
+  different values than the changed lines.
+- Only use `[ctx]` lines to understand the surrounding structure (class, method,
+  control flow).
+
 ## File Structure Annotations
 
-Each C# file diff may include a `[file-structure: compiles=yes, balanced-braces=yes]`
+Each C# file diff includes a `[file-structure: compiles=..., balanced-braces=...]`
 annotation. This was verified by the Roslyn compiler against the full file source.
 
 **When `compiles=yes` and `balanced-braces=yes`:** The file is structurally valid.
@@ -14,16 +29,26 @@ structural incompleteness — the complete file compiles without syntax errors.
 Any apparently missing structural elements exist in unchanged portions of the file
 that are not shown in the diff.
 
+**When any value is `unknown`:** The source code was unavailable for structural
+validation (download timeout, file too large, or file missing from the archive).
+Treat the file as structurally valid — do NOT report structural issues.
+
 **Only report structural issues when the annotation says `compiles=no` or
-`balanced-braces=no`, or when no `[file-structure]` annotation is present.**
+`balanced-braces=no`.**
 
 ## Review Instructions
 
-For each real issue found:
-- Classify severity: critical | major | minor
-- Specify the file path
-- Describe the issue concisely
-- Suggest a fix if applicable
+For each real issue found, format it as:
+
+```
+**[severity]** `file/path.cs` (line N): description
+```
+
+- `severity` is one of: `critical`, `major`, `minor`
+- `file/path.cs` is the file path in backticks
+- `(line N)` is optional — omit if no specific line applies
+- `description` is a single-line issue description; add a multi-line elaboration on
+  subsequent lines if needed
 
 Focus on: correctness, null safety, concurrency, async/await correctness, security,
 error handling, performance, missing tests.

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingFilterer.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingFilterer.cs
@@ -1,0 +1,70 @@
+using System.Text;
+
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// Reconstructs the final review text after validation. Emits <c>Valid</c> findings
+/// verbatim, <c>Uncertain</c> with a <c>[uncertain]</c> prefix, and omits
+/// <c>FalsePositive</c>. Preserves any unparseable prose that the parser couldn't
+/// structure. Appends a summary footer when at least one parseable finding exists.
+/// Feature 021.
+/// </summary>
+public static class FindingFilterer
+{
+    /// <summary>
+    /// Assembles the filtered output.
+    /// </summary>
+    /// <param name="unparseableRemainder">
+    /// Prose from the review that could not be matched as a structured finding
+    /// (headings, intros, free-form commentary). Preserved verbatim at the top of the
+    /// output so no content is silently dropped (FR-012).
+    /// </param>
+    /// <param name="validated">Validation verdicts in the same order as the original findings.</param>
+    public static string Apply(string unparseableRemainder, IReadOnlyList<ValidatedFinding> validated)
+    {
+        var sb = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(unparseableRemainder))
+            sb.Append(unparseableRemainder.TrimEnd()).AppendLine();
+
+        var validCount = 0;
+        var filteredCount = 0;
+        var uncertainCount = 0;
+
+        foreach (var v in validated)
+        {
+            switch (v.Verdict)
+            {
+                case FindingVerdict.Valid:
+                    sb.AppendLine(v.Finding.OriginalText);
+                    validCount++;
+                    break;
+                case FindingVerdict.Uncertain:
+                    sb.AppendLine("[uncertain] " + v.Finding.OriginalText);
+                    uncertainCount++;
+                    break;
+                case FindingVerdict.FalsePositive:
+                    filteredCount++;
+                    break;
+            }
+        }
+
+        // If everything was filtered and there's no remainder, produce a clear signal.
+        if (validated.Count > 0 && validCount == 0 && uncertainCount == 0 && string.IsNullOrWhiteSpace(unparseableRemainder))
+        {
+            sb.Clear();
+            sb.AppendLine("No issues found.");
+        }
+
+        // Summary footer is appended only when at least one parseable finding existed
+        // (SC-005 scoping). Reviews with zero findings get no footer.
+        if (validated.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("---");
+            sb.Append($"_Validation: {validCount} confirmed, {filteredCount} filtered, {uncertainCount} uncertain_");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingParser.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingParser.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// Parses Copilot review output into structured <see cref="ParsedFinding"/> records.
+/// Relies on the structured output format enforced by <c>copilot-page-review.md</c>:
+/// <c>**[severity]** `file/path.cs` (line N): description</c>.
+/// Feature 021.
+/// </summary>
+public static partial class FindingParser
+{
+    // One line per finding. Captures: severity, filePath, optional lineNumber, description.
+    // Example: **[critical]** `src/Foo.cs` (line 42): Null deref when X is empty
+    [GeneratedRegex(
+        @"^\*\*\[(?<sev>critical|major|minor)\]\*\*\s+`(?<file>[^`]+)`(?:\s*\(line\s+(?<line>\d+)\))?\s*:\s*(?<desc>.+?)$",
+        RegexOptions.Multiline | RegexOptions.IgnoreCase)]
+    private static partial Regex FindingPattern();
+
+    /// <summary>
+    /// Parses <paramref name="reviewText"/> into structured findings plus any
+    /// unparseable remainder. The remainder is preserved verbatim so
+    /// <see cref="FindingFilterer"/> can reassemble the output without data loss
+    /// (FR-012 — never silently drop content).
+    /// </summary>
+    public static (IReadOnlyList<ParsedFinding> Findings, string UnparseableRemainder) Parse(string reviewText)
+    {
+        if (string.IsNullOrWhiteSpace(reviewText))
+            return (Array.Empty<ParsedFinding>(), reviewText ?? "");
+
+        var findings = new List<ParsedFinding>();
+        var remainder = new StringBuilder();
+
+        var matches = FindingPattern().Matches(reviewText);
+        if (matches.Count == 0)
+            return (Array.Empty<ParsedFinding>(), reviewText);
+
+        // Everything before the first match is remainder prose (e.g., a heading
+        // like "## Critical Issues" or intro text).
+        var cursor = 0;
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var m = matches[i];
+
+            if (m.Index > cursor)
+                remainder.Append(reviewText, cursor, m.Index - cursor);
+
+            var sev = m.Groups["sev"].Value.ToLowerInvariant();
+            var file = m.Groups["file"].Value.Trim();
+            var lineStr = m.Groups["line"].Success ? m.Groups["line"].Value : null;
+            var desc = m.Groups["desc"].Value.Trim();
+
+            findings.Add(new ParsedFinding
+            {
+                Index = i,
+                FilePath = file,
+                LineNumber = lineStr is null ? null : int.Parse(lineStr),
+                Severity = sev,
+                Description = desc,
+                OriginalText = m.Value,
+            });
+
+            cursor = m.Index + m.Length;
+        }
+
+        // Trailing prose after the last finding (if any) is also remainder.
+        if (cursor < reviewText.Length)
+            remainder.Append(reviewText, cursor, reviewText.Length - cursor);
+
+        return (findings, remainder.ToString());
+    }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingScopeResolver.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingScopeResolver.cs
@@ -1,0 +1,120 @@
+using Microsoft.Extensions.Logging;
+using REBUSS.Pure.RoslynProcessor;
+
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// For each <see cref="ParsedFinding"/>, resolves the full source of its enclosing
+/// method/scope using <see cref="DiffSourceResolver"/> (to obtain the after-code for
+/// the file) and <see cref="FindingScopeExtractor"/> (to extract the enclosing member
+/// body via Roslyn). When scope extraction cannot produce a usable source block, the
+/// resolution failure reason is recorded so the validator can map it to the correct
+/// verdict (spec US3.1 / US3.2). Feature 021.
+/// </summary>
+public sealed class FindingScopeResolver
+{
+    private readonly DiffSourceResolver _sourceResolver;
+    private readonly ILogger<FindingScopeResolver> _logger;
+
+    public FindingScopeResolver(
+        DiffSourceResolver sourceResolver,
+        ILogger<FindingScopeResolver> logger)
+    {
+        _sourceResolver = sourceResolver;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Resolves scope for every finding. Groups lookups by file path to benefit from
+    /// <see cref="DiffSourceResolver"/>'s internal per-file cache — one resolve call
+    /// per distinct file regardless of finding count.
+    /// </summary>
+    public async Task<IReadOnlyList<FindingWithScope>> ResolveAsync(
+        IReadOnlyList<ParsedFinding> findings,
+        int maxScopeLines,
+        CancellationToken ct)
+    {
+        if (findings.Count == 0)
+            return Array.Empty<FindingWithScope>();
+
+        var results = new FindingWithScope[findings.Count];
+        var byFile = findings
+            .Select((f, idx) => (finding: f, idx))
+            .GroupBy(pair => pair.finding.FilePath, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var group in byFile)
+        {
+            var filePath = group.Key;
+
+            // (a) Non-C# files — Roslyn does not apply. Passthrough per spec US3.1.
+            if (!filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var (f, idx) in group)
+                    results[idx] = UnresolvedResult(f, ScopeResolutionFailure.NotCSharp);
+                continue;
+            }
+
+            // (b) Resolve source once per file. The DiffSourceResolver caches internally,
+            // but we still synthesize a diff-like header so the resolver can parse the path.
+            var diffHeader = $"=== {filePath} (edit: +0 -0) ===\n@@ -1,1 +1,1 @@\n";
+            DiffSourcePair? pair;
+            try
+            {
+                pair = await _sourceResolver.ResolveAsync(diffHeader, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Scope resolution failed for {FilePath}; tagging as uncertain", filePath);
+                foreach (var (f, idx) in group)
+                    results[idx] = UnresolvedResult(f, ScopeResolutionFailure.SourceUnavailable);
+                continue;
+            }
+
+            if (pair is null)
+            {
+                foreach (var (f, idx) in group)
+                    results[idx] = UnresolvedResult(f, ScopeResolutionFailure.SourceUnavailable);
+                continue;
+            }
+
+            // (c) Per-finding scope extraction against the single resolved source.
+            foreach (var (f, idx) in group)
+            {
+                if (f.LineNumber is null)
+                {
+                    // No line number cited → cannot locate enclosing scope.
+                    results[idx] = UnresolvedResult(f, ScopeResolutionFailure.ScopeNotFound);
+                    continue;
+                }
+
+                var (body, name, resolved) = FindingScopeExtractor.ExtractScopeBody(
+                    pair.AfterCode, f.LineNumber.Value, maxScopeLines);
+
+                results[idx] = resolved
+                    ? new FindingWithScope
+                    {
+                        Finding = f,
+                        ScopeSource = body,
+                        ScopeName = name,
+                        ResolutionFailure = ScopeResolutionFailure.None,
+                    }
+                    : UnresolvedResult(f, ScopeResolutionFailure.ScopeNotFound);
+            }
+        }
+
+        return results;
+    }
+
+    private static FindingWithScope UnresolvedResult(ParsedFinding finding, ScopeResolutionFailure failure) =>
+        new()
+        {
+            Finding = finding,
+            ScopeSource = "",
+            ScopeName = "",
+            ResolutionFailure = failure,
+        };
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingValidator.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingValidator.cs
@@ -1,0 +1,272 @@
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using GitHub.Copilot.SDK;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using REBUSS.Pure.Core.Services.CopilotReview;
+
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// Validates review findings by presenting each (with its enclosing scope source)
+/// to a second Copilot pass. Findings whose scope could not be resolved bypass the
+/// validator with a deterministic verdict per spec US3.1 / US3.2. Feature 021.
+/// </summary>
+public sealed partial class FindingValidator
+{
+    private const string PromptResourceName = "REBUSS.Pure.Services.CopilotReview.Prompts.copilot-finding-validation.md";
+    private static string? _cachedPromptTemplate;
+
+    [GeneratedRegex(
+        @"\*\*\s*Finding\s+(?<n>\d+)\s*:\s*(?<verdict>VALID|FALSE_POSITIVE|UNCERTAIN)\s*\*\*\s*(?:[—\-–:]\s*(?<reason>[^\n\r]*))?",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex VerdictPattern();
+
+    private readonly ICopilotSessionFactory _sessionFactory;
+    private readonly IOptions<CopilotReviewOptions> _options;
+    private readonly ILogger<FindingValidator> _logger;
+
+    public FindingValidator(
+        ICopilotSessionFactory sessionFactory,
+        IOptions<CopilotReviewOptions> options,
+        ILogger<FindingValidator> logger)
+    {
+        _sessionFactory = sessionFactory;
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Validates each finding. Options are read at method invocation (Principle V),
+    /// not cached in the constructor, so configuration hot-reload is respected.
+    /// </summary>
+    public async Task<IReadOnlyList<ValidatedFinding>> ValidateAsync(
+        IReadOnlyList<FindingWithScope> findings,
+        CancellationToken ct)
+    {
+        if (findings.Count == 0)
+            return Array.Empty<ValidatedFinding>();
+
+        var opts = _options.Value;
+        var results = new ValidatedFinding[findings.Count];
+
+        // Phase 1: deterministic verdicts for findings whose scope could not be resolved.
+        // No Copilot call needed.
+        var toValidate = new List<(FindingWithScope Item, int Index)>();
+        for (var i = 0; i < findings.Count; i++)
+        {
+            var f = findings[i];
+            switch (f.ResolutionFailure)
+            {
+                case ScopeResolutionFailure.NotCSharp:
+                    // Spec US3.1: non-C# files pass through unfiltered.
+                    results[i] = new ValidatedFinding
+                    {
+                        Finding = f.Finding,
+                        Verdict = FindingVerdict.Valid,
+                        Reason = "non-C# file; scope validation not applicable",
+                    };
+                    break;
+                case ScopeResolutionFailure.SourceUnavailable:
+                    results[i] = new ValidatedFinding
+                    {
+                        Finding = f.Finding,
+                        Verdict = FindingVerdict.Uncertain,
+                        Reason = "source code unavailable for validation",
+                    };
+                    break;
+                case ScopeResolutionFailure.ScopeNotFound:
+                    results[i] = new ValidatedFinding
+                    {
+                        Finding = f.Finding,
+                        Verdict = FindingVerdict.Uncertain,
+                        Reason = "enclosing scope could not be located",
+                    };
+                    break;
+                case ScopeResolutionFailure.None:
+                    toValidate.Add((f, i));
+                    break;
+            }
+        }
+
+        if (toValidate.Count == 0)
+            return results;
+
+        // Phase 2: batch the resolvable findings and validate against Copilot.
+        var batchSize = Math.Max(1, opts.ValidationBatchSize);
+        for (var start = 0; start < toValidate.Count; start += batchSize)
+        {
+            var batch = toValidate.GetRange(start, Math.Min(batchSize, toValidate.Count - start));
+            ct.ThrowIfCancellationRequested();
+
+            try
+            {
+                var batchResults = await ValidateBatchAsync(batch, opts.Model, ct).ConfigureAwait(false);
+                for (var j = 0; j < batch.Count; j++)
+                {
+                    var (item, resultIdx) = batch[j];
+                    results[resultIdx] = batchResults[j]
+                        ?? new ValidatedFinding
+                        {
+                            Finding = item.Finding,
+                            Verdict = FindingVerdict.Valid, // conservative: unparsed verdict → keep finding
+                            Reason = "validator response missing this finding",
+                        };
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Validation batch starting at index {Start} failed; findings will pass through unfiltered",
+                    start);
+                foreach (var (item, resultIdx) in batch)
+                {
+                    results[resultIdx] = new ValidatedFinding
+                    {
+                        Finding = item.Finding,
+                        Verdict = FindingVerdict.Valid, // graceful degradation (FR-012)
+                        Reason = $"validation call failed: {ex.Message}",
+                    };
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private async Task<ValidatedFinding?[]> ValidateBatchAsync(
+        IReadOnlyList<(FindingWithScope Item, int Index)> batch,
+        string model,
+        CancellationToken ct)
+    {
+        var prompt = BuildPrompt(batch);
+
+        ICopilotSessionHandle? handle = null;
+        try
+        {
+            handle = await _sessionFactory.CreateSessionAsync(model, ct).ConfigureAwait(false);
+
+            var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+            string? capturedContent = null;
+
+            using var subscription = handle.On(evt =>
+            {
+                switch (evt)
+                {
+                    case AssistantMessageEvent msg:
+                        capturedContent = msg.Data?.Content;
+                        break;
+                    case SessionErrorEvent err:
+                        tcs.TrySetException(new InvalidOperationException(
+                            err.Data?.Message ?? "session error (no message)"));
+                        break;
+                    case SessionIdleEvent:
+                        if (!string.IsNullOrWhiteSpace(capturedContent))
+                            tcs.TrySetResult(capturedContent!);
+                        else
+                            tcs.TrySetException(new InvalidOperationException(
+                                "session idle without assistant message content"));
+                        break;
+                }
+            });
+
+            await handle.SendAsync(prompt, ct).ConfigureAwait(false);
+            var responseText = await tcs.Task.WaitAsync(ct).ConfigureAwait(false);
+
+            return ParseVerdicts(responseText, batch);
+        }
+        finally
+        {
+            if (handle is not null)
+            {
+                try { await handle.DisposeAsync().ConfigureAwait(false); } catch { /* swallow */ }
+            }
+        }
+    }
+
+    private static string BuildPrompt(IReadOnlyList<(FindingWithScope Item, int Index)> batch)
+    {
+        var sb = new StringBuilder();
+        for (var i = 0; i < batch.Count; i++)
+        {
+            var finding = batch[i].Item.Finding;
+            var scope = batch[i].Item;
+            sb.AppendLine($"## Finding {i + 1}");
+            sb.AppendLine($"**Severity:** {finding.Severity}");
+            sb.AppendLine($"**File:** {finding.FilePath}{(finding.LineNumber is int ln ? $" (line {ln})" : "")}");
+            sb.AppendLine($"**Issue:** {finding.Description}");
+            sb.AppendLine();
+            sb.AppendLine($"### Source code of enclosing scope: `{scope.ScopeName}`");
+            sb.AppendLine("```csharp");
+            sb.AppendLine(scope.ScopeSource);
+            sb.AppendLine("```");
+            sb.AppendLine();
+        }
+
+        return LoadPromptTemplate().Replace("{findingsWithScopes}", sb.ToString());
+    }
+
+    private static ValidatedFinding?[] ParseVerdicts(
+        string responseText,
+        IReadOnlyList<(FindingWithScope Item, int Index)> batch)
+    {
+        var verdicts = new ValidatedFinding?[batch.Count];
+        var matches = VerdictPattern().Matches(responseText);
+
+        foreach (Match m in matches)
+        {
+            if (!int.TryParse(m.Groups["n"].Value, out var n) || n < 1 || n > batch.Count)
+                continue;
+
+            var verdictStr = m.Groups["verdict"].Value.ToUpperInvariant();
+            var verdict = verdictStr switch
+            {
+                "VALID" => FindingVerdict.Valid,
+                "FALSE_POSITIVE" => FindingVerdict.FalsePositive,
+                "UNCERTAIN" => FindingVerdict.Uncertain,
+                _ => FindingVerdict.Valid, // conservative fallback
+            };
+
+            var reason = m.Groups["reason"].Success ? m.Groups["reason"].Value.Trim() : null;
+            verdicts[n - 1] = new ValidatedFinding
+            {
+                Finding = batch[n - 1].Item.Finding,
+                Verdict = verdict,
+                Reason = string.IsNullOrWhiteSpace(reason) ? null : reason,
+            };
+        }
+
+        return verdicts;
+    }
+
+    private static string LoadPromptTemplate()
+    {
+        return LazyInitializer.EnsureInitialized(ref _cachedPromptTemplate, () =>
+        {
+            var assembly = typeof(FindingValidator).Assembly;
+            var stream = assembly.GetManifestResourceStream(PromptResourceName);
+            if (stream is null)
+            {
+                var match = Array.Find(
+                    assembly.GetManifestResourceNames(),
+                    n => n.EndsWith("copilot-finding-validation.md", StringComparison.OrdinalIgnoreCase));
+                if (match is not null)
+                    stream = assembly.GetManifestResourceStream(match);
+            }
+            if (stream is null)
+                throw new FileNotFoundException(
+                    "Embedded resource 'copilot-finding-validation.md' not found in REBUSS.Pure assembly.");
+
+            using (stream)
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+        })!;
+    }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingVerdict.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingVerdict.cs
@@ -1,0 +1,23 @@
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// Verdict rendered by the finding validator for a single review finding.
+/// Feature 021 (false-positive reduction).
+/// </summary>
+public enum FindingVerdict
+{
+    /// <summary>Issue genuinely exists in the source code.</summary>
+    Valid,
+
+    /// <summary>
+    /// Issue does not exist; caused by diff context misinterpretation or
+    /// incomplete code visibility. Filtered from final output.
+    /// </summary>
+    FalsePositive,
+
+    /// <summary>
+    /// Cannot determine from the provided scope alone. Tagged with
+    /// <c>[uncertain]</c> prefix in final output — never silently dropped.
+    /// </summary>
+    Uncertain,
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/FindingWithScope.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/FindingWithScope.cs
@@ -1,0 +1,31 @@
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// A finding paired with the full source code of its enclosing method/scope, resolved by
+/// <see cref="FindingScopeResolver"/>. When scope extraction fails, <see cref="ResolutionFailure"/>
+/// indicates why — the validator uses this to decide whether to call Copilot or short-circuit
+/// to a verdict. Feature 021.
+/// </summary>
+public sealed record FindingWithScope
+{
+    /// <summary>The original parsed finding.</summary>
+    public required ParsedFinding Finding { get; init; }
+
+    /// <summary>
+    /// Full source code of the enclosing method, property, constructor, or class body.
+    /// Empty string if scope was not resolved.
+    /// </summary>
+    public required string ScopeSource { get; init; }
+
+    /// <summary>
+    /// Formatted scope name from <c>ScopeResolver</c> (e.g., <c>"GitHubScmClientTests.ctor(...)"</c>).
+    /// Empty string if scope was not resolved.
+    /// </summary>
+    public required string ScopeName { get; init; }
+
+    /// <summary>
+    /// <see cref="ScopeResolutionFailure.None"/> when scope was extracted; otherwise indicates why
+    /// resolution failed. Drives the validator's verdict mapping for unresolved findings.
+    /// </summary>
+    public required ScopeResolutionFailure ResolutionFailure { get; init; }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/ParsedFinding.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/ParsedFinding.cs
@@ -1,0 +1,29 @@
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// A single review finding extracted from Copilot's <c>ReviewText</c> by
+/// <see cref="FindingParser"/>. Feature 021.
+/// </summary>
+public sealed record ParsedFinding
+{
+    /// <summary>Ordinal position in the review text (0-based). Used for stable ordering.</summary>
+    public required int Index { get; init; }
+
+    /// <summary>File path cited in the finding (e.g., <c>src/Services/Foo.cs</c>).</summary>
+    public required string FilePath { get; init; }
+
+    /// <summary>Line number cited in the finding; <c>null</c> if Copilot omitted a line reference.</summary>
+    public int? LineNumber { get; init; }
+
+    /// <summary>One of <c>critical</c>, <c>major</c>, <c>minor</c>.</summary>
+    public required string Severity { get; init; }
+
+    /// <summary>Human-readable issue description.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// Raw text block for this finding as it appears in <c>ReviewText</c>.
+    /// Used by <see cref="FindingFilterer"/> to locate and remove/tag the finding.
+    /// </summary>
+    public required string OriginalText { get; init; }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/ScopeResolutionFailure.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/ScopeResolutionFailure.cs
@@ -1,0 +1,31 @@
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// Reason that the scope of a finding could not be resolved — drives the validator's
+/// pre-filter mapping (spec US3.1 / US3.2). Feature 021.
+/// </summary>
+public enum ScopeResolutionFailure
+{
+    /// <summary>Scope was successfully extracted and the finding will be validated by Copilot.</summary>
+    None,
+
+    /// <summary>
+    /// Finding's file path is not a <c>.cs</c> file — Roslyn analysis is not applicable.
+    /// Maps to <c>Verdict = Valid</c> (passthrough unfiltered per spec US3.1).
+    /// </summary>
+    NotCSharp,
+
+    /// <summary>
+    /// File is C# but <c>DiffSourceResolver</c> could not resolve its source
+    /// (download timeout, file missing from archive, >100KB). Maps to
+    /// <c>Verdict = Uncertain</c> (tagged per spec US3.2).
+    /// </summary>
+    SourceUnavailable,
+
+    /// <summary>
+    /// File source is available but no enclosing member could be mapped to the
+    /// finding's line (e.g., top-level statement, class-level field outside any
+    /// method). Maps to <c>Verdict = Uncertain</c> (tagged per spec US3.2).
+    /// </summary>
+    ScopeNotFound,
+}

--- a/REBUSS.Pure/Services/CopilotReview/Validation/ValidatedFinding.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Validation/ValidatedFinding.cs
@@ -1,0 +1,19 @@
+namespace REBUSS.Pure.Services.CopilotReview.Validation;
+
+/// <summary>
+/// A finding after the validation pass, carrying a verdict. Feature 021.
+/// </summary>
+public sealed record ValidatedFinding
+{
+    /// <summary>The original parsed finding.</summary>
+    public required ParsedFinding Finding { get; init; }
+
+    /// <summary>
+    /// Verdict: <see cref="FindingVerdict.Valid"/> (keep), <see cref="FindingVerdict.FalsePositive"/>
+    /// (remove), or <see cref="FindingVerdict.Uncertain"/> (tag with <c>[uncertain]</c>).
+    /// </summary>
+    public required FindingVerdict Verdict { get; init; }
+
+    /// <summary>One-sentence explanation from the validation model. <c>null</c> if the finding skipped validation.</summary>
+    public string? Reason { get; init; }
+}


### PR DESCRIPTION
Implements Feature 021: a full finding validation pipeline for Copilot reviews. Findings are parsed, their enclosing method/scope is resolved via Roslyn, and each is validated against actual source code using a second Copilot call. False positives are filtered, uncertain findings are tagged, and a summary footer is appended. Includes new prompt resources, DI registration, config options, and extensive unit tests. Also updates context line handling (`[ctx]` prefix) and file structure annotations for improved review accuracy.