### PR TITLE
Copilot review inspection writer (feature 022)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # REBUSS.Pure Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-12
+Auto-generated from all feature plans. Last updated: 2026-04-14
 
 ## Active Technologies
 - C# 14 on .NET 10 (`net10.0`), `<Nullable>enable</Nullable>` + Microsoft.Extensions.Logging, Microsoft.Extensions.Http (Polly via `AddStandardResilienceHandler`) (014-log-noise-reduction)

--- a/REBUSS.Pure.Core/Services/CopilotReview/ICopilotPageReviewer.cs
+++ b/REBUSS.Pure.Core/Services/CopilotReview/ICopilotPageReviewer.cs
@@ -20,7 +20,13 @@ public interface ICopilotPageReviewer
     /// <c>FailedFilePaths</c> list — the orchestrator fills in the file paths because
     /// only the orchestrator knows which files were on the page.
     /// </summary>
+    /// <param name="reviewKey">
+    /// Opaque review identifier from the orchestrator (e.g., <c>pr:42</c>, <c>local:staged:/repo</c>).
+    /// Used by the optional inspection writer (feature 022) to group captured prompts and
+    /// responses under a per-PR subdirectory. No other downstream consumer uses this value.
+    /// </param>
     Task<CopilotPageReviewResult> ReviewPageAsync(
+        string reviewKey,
         int pageNumber,
         string enrichedPageContent,
         CancellationToken ct = default);

--- a/REBUSS.Pure.Tests/Services/CopilotReview/CopilotPageReviewerTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/CopilotPageReviewerTests.cs
@@ -1,8 +1,10 @@
 using GitHub.Copilot.SDK;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using NSubstitute;
 using REBUSS.Pure.Core.Services.CopilotReview;
 using REBUSS.Pure.Services.CopilotReview;
+using REBUSS.Pure.Services.CopilotReview.Inspection;
 
 namespace REBUSS.Pure.Tests.Services.CopilotReview;
 
@@ -19,10 +21,13 @@ namespace REBUSS.Pure.Tests.Services.CopilotReview;
 /// </summary>
 public class CopilotPageReviewerTests
 {
-    private static CopilotPageReviewer CreateReviewer(FakeSessionFactory factory) =>
+    private static CopilotPageReviewer CreateReviewer(
+        FakeSessionFactory factory,
+        ICopilotInspectionWriter? inspection = null) =>
         new(factory,
             Options.Create(new CopilotReviewOptions { Model = "claude-sonnet-4.6" }),
-            NullLogger<CopilotPageReviewer>.Instance);
+            NullLogger<CopilotPageReviewer>.Instance,
+            inspection ?? new NoOpCopilotInspectionWriter());
 
     [Fact]
     public async Task ReviewPage_AssistantMessageThenIdle_ReturnsSuccessWithReviewText()
@@ -35,7 +40,7 @@ public class CopilotPageReviewerTests
         };
 
         var reviewer = CreateReviewer(factory);
-        var result = await reviewer.ReviewPageAsync(1, "diff content");
+        var result = await reviewer.ReviewPageAsync("pr:42", 1, "diff content");
 
         Assert.True(result.Succeeded);
         Assert.Equal(1, result.PageNumber);
@@ -53,7 +58,7 @@ public class CopilotPageReviewerTests
         };
 
         var reviewer = CreateReviewer(factory);
-        var result = await reviewer.ReviewPageAsync(2, "diff");
+        var result = await reviewer.ReviewPageAsync("pr:42", 2, "diff");
 
         Assert.False(result.Succeeded);
         Assert.Contains("model unavailable", result.ErrorMessage);
@@ -70,7 +75,7 @@ public class CopilotPageReviewerTests
         };
 
         var reviewer = CreateReviewer(factory);
-        var result = await reviewer.ReviewPageAsync(3, "diff");
+        var result = await reviewer.ReviewPageAsync("pr:42", 3, "diff");
 
         Assert.False(result.Succeeded);
         Assert.Contains("idle without assistant message", result.ErrorMessage);
@@ -89,7 +94,7 @@ public class CopilotPageReviewerTests
         };
 
         var reviewer = CreateReviewer(factory);
-        _ = await reviewer.ReviewPageAsync(1, "MY_DIFF_MARKER_xyz");
+        _ = await reviewer.ReviewPageAsync("pr:42", 1, "MY_DIFF_MARKER_xyz");
 
         Assert.NotNull(capturedPrompt);
         Assert.Contains("Code Review Task", capturedPrompt); // from template
@@ -108,10 +113,83 @@ public class CopilotPageReviewerTests
 
         var reviewer = CreateReviewer(factory);
         using var cts = new CancellationTokenSource();
-        var task = reviewer.ReviewPageAsync(1, "diff", cts.Token);
+        var task = reviewer.ReviewPageAsync("pr:42", 1, "diff", cts.Token);
         cts.Cancel();
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await task);
+    }
+
+    // ─── Feature 022 — inspection writer integration ─────────────────────────────
+
+    [Fact]
+    public async Task ReviewPage_SuccessfulPath_WritesPromptAndResponseToInspection()
+    {
+        // Arrange: reviewer with a Substitute inspection writer; successful review.
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            h.PushEvent(new AssistantMessageEvent { Data = new AssistantMessageData { MessageId = "m1", Content = "review body" } });
+            h.PushEvent(new SessionIdleEvent { Data = new SessionIdleData() });
+        };
+        var inspection = Substitute.For<ICopilotInspectionWriter>();
+        var reviewer = CreateReviewer(factory, inspection);
+
+        // Act
+        var result = await reviewer.ReviewPageAsync("pr:42", 1, "MY_DIFF_MARKER");
+
+        // Assert: review succeeded, and both prompt and response were captured with the
+        // correct review key and step descriptor.
+        Assert.True(result.Succeeded);
+        await inspection.Received(1).WritePromptAsync(
+            "pr:42", "page-1-review",
+            Arg.Is<string>(s => s.Contains("MY_DIFF_MARKER")),
+            Arg.Any<CancellationToken>());
+        await inspection.Received(1).WriteResponseAsync(
+            "pr:42", "page-1-review", "review body",
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReviewPage_NoOpInspection_ReviewTextUnchanged()
+    {
+        // Feature 022 US4 (T022): verify the NoOp inspection writer doesn't mutate the
+        // review text in any way. The reviewer's output must match what Copilot returned
+        // byte-for-byte regardless of which inspection writer is wired in.
+        const string copilotResponse = "**[critical]** `src/Foo.cs` (line 5): null deref";
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            h.PushEvent(new AssistantMessageEvent { Data = new AssistantMessageData { MessageId = "m", Content = copilotResponse } });
+            h.PushEvent(new SessionIdleEvent { Data = new SessionIdleData() });
+        };
+        var reviewer = CreateReviewer(factory, new NoOpCopilotInspectionWriter());
+
+        var result = await reviewer.ReviewPageAsync("pr:42", 1, "diff content");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(copilotResponse, result.ReviewText);
+    }
+
+    [Fact]
+    public async Task ReviewPage_FailurePath_OnlyPromptIsCaptured()
+    {
+        // When the SDK session errors, the response was never produced, so the response
+        // capture must NOT fire. Prompt capture still happens (it's sent before the SDK call).
+        var factory = new FakeSessionFactory();
+        factory.OnSendAsync = (h, _) =>
+        {
+            h.PushEvent(new SessionErrorEvent { Data = new SessionErrorData { ErrorType = "model", Message = "boom" } });
+        };
+        var inspection = Substitute.For<ICopilotInspectionWriter>();
+        var reviewer = CreateReviewer(factory, inspection);
+
+        var result = await reviewer.ReviewPageAsync("pr:42", 1, "content");
+
+        Assert.False(result.Succeeded);
+        await inspection.Received(1).WritePromptAsync(
+            "pr:42", "page-1-review", Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await inspection.DidNotReceive().WriteResponseAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // ─── Fakes ────────────────────────────────────────────────────────────────────

--- a/REBUSS.Pure.Tests/Services/CopilotReview/CopilotReviewOrchestratorTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/CopilotReviewOrchestratorTests.cs
@@ -79,7 +79,7 @@ public class CopilotReviewOrchestratorTests
     public async Task TriggerReview_AllPagesSucceed_ResultContainsAllPages()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1)));
 
         var orchestrator = Create(reviewer);
@@ -97,7 +97,7 @@ public class CopilotReviewOrchestratorTests
     public async Task TriggerReview_Idempotent_SamePrDoesNotRetrigger()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1)));
 
         var orchestrator = Create(reviewer);
@@ -109,7 +109,7 @@ public class CopilotReviewOrchestratorTests
 
         // 2 pages × 1 trigger = 2 calls total (not 6).
         await reviewer.Received(2).ReviewPageAsync(
-            Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -125,7 +125,7 @@ public class CopilotReviewOrchestratorTests
     public async Task TryGetSnapshot_AfterCompletion_ReturnsReadyWithResult()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1)));
 
         var orchestrator = Create(reviewer);
@@ -143,7 +143,7 @@ public class CopilotReviewOrchestratorTests
     public async Task TryGetSnapshot_AfterCompletion_ExposesTotalAndCompletedPages()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1)));
 
         var orchestrator = Create(reviewer);
@@ -167,7 +167,7 @@ public class CopilotReviewOrchestratorTests
 
         Assert.Equal(0, result.TotalPages);
         await reviewer.DidNotReceive().ReviewPageAsync(
-            Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     // ─── Feature 013 Phase 5 US3 (T037) — 3-attempt retry scenarios ──────────────
@@ -177,7 +177,7 @@ public class CopilotReviewOrchestratorTests
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
         var callCount = 0;
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
                 callCount++;
@@ -203,7 +203,7 @@ public class CopilotReviewOrchestratorTests
     public async Task ReviewPage_AllThreeAttemptsFail_ResultMarkedFailedWithFilePaths()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Failure(
                 ci.Arg<int>(), Array.Empty<string>(), "persistent error", 1)));
 
@@ -222,7 +222,7 @@ public class CopilotReviewOrchestratorTests
 
         // Reviewer invoked exactly 3 times (one page × 3 attempts).
         await reviewer.Received(3).ReviewPageAsync(
-            Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -230,7 +230,7 @@ public class CopilotReviewOrchestratorTests
     {
         // Page 1 always succeeds, page 2 always fails.
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
                 var pageNumber = ci.Arg<int>();
@@ -255,7 +255,7 @@ public class CopilotReviewOrchestratorTests
     public async Task Orchestrator_AllPagesFail_ResultReturnsAllFailedNotException()
     {
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => Task.FromResult(CopilotPageReviewResult.Failure(
                 ci.Arg<int>(), Array.Empty<string>(), "down", 1)));
 
@@ -279,7 +279,7 @@ public class CopilotReviewOrchestratorTests
     {
         // Arrange: reviewer that always succeeds.
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1));
 
         var orchestrator = Create(reviewer);
@@ -316,7 +316,7 @@ public class CopilotReviewOrchestratorTests
         const int pageCount = 3;
 
         var reviewer = Substitute.For<ICopilotPageReviewer>();
-        reviewer.ReviewPageAsync(Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(async ci =>
             {
                 await Task.Delay(pageDelayMs);
@@ -339,5 +339,23 @@ public class CopilotReviewOrchestratorTests
         var sequentialMinMs = pageCount * pageDelayMs;
         Assert.True(sw.ElapsedMilliseconds < sequentialMinMs,
             $"Expected parallel execution under {sequentialMinMs}ms, but took {sw.ElapsedMilliseconds}ms");
+    }
+
+    [Fact]
+    public async Task TriggerReview_PropagatesReviewKeyToPageReviewer()
+    {
+        // Feature 022: orchestrator must pass the review key as the first argument to
+        // ICopilotPageReviewer.ReviewPageAsync so the inspection writer can group output
+        // under a per-PR subdirectory.
+        var reviewer = Substitute.For<ICopilotPageReviewer>();
+        reviewer.ReviewPageAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(CopilotPageReviewResult.Success(ci.Arg<int>(), "ok", 1)));
+
+        var orchestrator = Create(reviewer);
+        orchestrator.TriggerReview("pr:42", BuildEnrichment());
+        _ = await orchestrator.WaitForReviewAsync("pr:42", CancellationToken.None);
+
+        await reviewer.Received().ReviewPageAsync(
+            "pr:42", Arg.Any<int>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 }

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/CopilotInspectionRegistrationTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/CopilotInspectionRegistrationTests.cs
@@ -1,0 +1,190 @@
+using Microsoft.Extensions.DependencyInjection;
+using REBUSS.Pure.Services.CopilotReview.Inspection;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Verifies the env-var-gated DI registration of <see cref="ICopilotInspectionWriter"/>.
+/// Feature 022 US2 (activation) + US4 (zero-impact when inactive).
+///
+/// Uses a tiny composition helper that mirrors the <c>Program.cs</c> gate logic — we don't
+/// stand up the whole host (slow + brittle) and we don't compose against the real
+/// <see cref="Microsoft.Extensions.Logging.ILogger{T}"/>; we register a <c>NullLogger</c>.
+/// All env-var manipulation is wrapped in try/finally to avoid polluting other tests.
+/// </summary>
+public class CopilotInspectionRegistrationTests
+{
+    private const string EnvVarName = "REBUSS_COPILOT_INSPECT";
+
+    private static ICopilotInspectionWriter ResolveWriter(string? envValue)
+    {
+        var prior = Environment.GetEnvironmentVariable(EnvVarName);
+        try
+        {
+            Environment.SetEnvironmentVariable(EnvVarName, envValue);
+            var services = new ServiceCollection();
+            services.AddLogging(); // satisfies ILogger<T> ctor dep on the filesystem writer
+            ApplyGate(services);
+            using var provider = services.BuildServiceProvider();
+            return provider.GetRequiredService<ICopilotInspectionWriter>();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(EnvVarName, prior);
+        }
+    }
+
+    /// <summary>
+    /// Mirrors the env-var gate in <c>Program.cs</c>. Tests this composition in isolation.
+    /// If <c>Program.cs</c> changes the gate logic, this helper must change too — the test
+    /// file is the canonical reference.
+    /// </summary>
+    private static void ApplyGate(IServiceCollection services)
+    {
+        var inspectEnabled = Environment.GetEnvironmentVariable(EnvVarName)
+            is "1" or "true" or "True";
+        if (inspectEnabled)
+            services.AddSingleton<ICopilotInspectionWriter, FileSystemCopilotInspectionWriter>();
+        else
+            services.AddSingleton<ICopilotInspectionWriter, NoOpCopilotInspectionWriter>();
+    }
+
+    [Fact]
+    public void EnvVarUnset_ResolvesToNoOp()
+    {
+        var writer = ResolveWriter(null);
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVar1_ResolvesToFileSystem()
+    {
+        var writer = ResolveWriter("1");
+        Assert.IsType<FileSystemCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarTrue_LowerCase_ResolvesToFileSystem()
+    {
+        var writer = ResolveWriter("true");
+        Assert.IsType<FileSystemCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarTrue_CapitalizedFirst_ResolvesToFileSystem()
+    {
+        var writer = ResolveWriter("True");
+        Assert.IsType<FileSystemCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVar0_ResolvesToNoOp()
+    {
+        var writer = ResolveWriter("0");
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarFalse_ResolvesToNoOp()
+    {
+        var writer = ResolveWriter("false");
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarYes_ResolvesToNoOp()
+    {
+        // Intentionally narrow enabling-value list (research.md Decision 6) — "yes" is NOT enabled.
+        var writer = ResolveWriter("yes");
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarTRUE_AllCaps_ResolvesToNoOp()
+    {
+        // Case-sensitive: only "1", "true" (lowercase), "True" (leading capital) enable.
+        var writer = ResolveWriter("TRUE");
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    [Fact]
+    public void EnvVarEmpty_ResolvesToNoOp()
+    {
+        var writer = ResolveWriter("");
+        Assert.IsType<NoOpCopilotInspectionWriter>(writer);
+    }
+
+    // ─── Feature 022 US4 (T021) — zero-impact verification ────────────────────────
+
+    // ─── Feature 022 T026 — SC-002 performance overhead microbench ───────────────
+
+    [Fact]
+    public async Task EnvVarUnset_NoOpWriter_HasNegligibleOverhead()
+    {
+        // Microbench: NoOp writer's overhead should be small enough that 10 000 calls
+        // complete in under 2× the cost of a tight loop doing nothing meaningful.
+        // SC-002's true target ("review wall time within 1% of baseline") is dominated
+        // by SDK network I/O and isn't measurable in a unit test — this guard simply
+        // prevents the NoOp from accidentally doing real work (e.g., file I/O, allocations
+        // proportional to content size).
+        const int iterations = 10_000;
+        const string content = "small content payload of about 100 bytes for the bench loop here";
+
+        var writer = new NoOpCopilotInspectionWriter();
+
+        // Warmup
+        for (var i = 0; i < 100; i++)
+            await writer.WritePromptAsync("k", "kind", content, CancellationToken.None);
+
+        // Baseline: empty loop.
+        var sw1 = System.Diagnostics.Stopwatch.StartNew();
+        for (var i = 0; i < iterations; i++)
+        {
+            // Empty body — measures pure loop + checkbox cost.
+        }
+        sw1.Stop();
+        var baselineMs = sw1.ElapsedMilliseconds;
+
+        // Measured: NoOp calls.
+        var sw2 = System.Diagnostics.Stopwatch.StartNew();
+        for (var i = 0; i < iterations; i++)
+        {
+            await writer.WritePromptAsync("k", "kind", content, CancellationToken.None);
+        }
+        sw2.Stop();
+        var measuredMs = sw2.ElapsedMilliseconds;
+
+        // Loose assertion: NoOp must finish in well under 100 ms for 10k calls.
+        // Tight bound versus baseline is too noisy on CI; absolute bound is the actual signal.
+        Assert.True(measuredMs < 100,
+            $"NoOp inspection writer is too slow: {measuredMs}ms for {iterations} calls (baseline empty loop: {baselineMs}ms)");
+    }
+
+    [Fact]
+    public async Task NoOpWriter_ManyCalls_TouchesNoFilesystemPath()
+    {
+        // Direct instantiation (not via DI) — verify NoOp truly performs no IO.
+        var writer = new NoOpCopilotInspectionWriter();
+
+        // Watch path under temp; nothing inside this directory should ever be created.
+        var watchDir = Path.Combine(Path.GetTempPath(), $"copilot-inspection-noop-watch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(watchDir);
+        try
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                await writer.WritePromptAsync($"pr:{i}", "page-1-review", "anything", CancellationToken.None);
+                await writer.WriteResponseAsync($"pr:{i}", "page-1-review", "anything", CancellationToken.None);
+            }
+
+            // No files or subdirectories should have appeared under the watch dir.
+            Assert.False(
+                Directory.EnumerateFileSystemEntries(watchDir).Any(),
+                "NoOpCopilotInspectionWriter must not write anywhere on the filesystem.");
+        }
+        finally
+        {
+            try { Directory.Delete(watchDir, recursive: true); } catch { }
+        }
+    }
+}

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriterTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriterTests.cs
@@ -1,0 +1,354 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Microsoft.Extensions.Logging;
+using REBUSS.Pure.Services.CopilotReview.Inspection;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Tests for <see cref="FileSystemCopilotInspectionWriter"/>. Feature 022.
+/// All tests use a temp base directory — never the real %LOCALAPPDATA%.
+/// </summary>
+public class FileSystemCopilotInspectionWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public FileSystemCopilotInspectionWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"copilot-inspection-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_tempDir)) Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private FileSystemCopilotInspectionWriter CreateWriter() =>
+        new(_tempDir, NullLogger<FileSystemCopilotInspectionWriter>.Instance);
+
+    [Fact]
+    public async Task WritePromptAsync_FirstCall_CreatesPerPrSubdirectoryAndFile()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", "hello", CancellationToken.None);
+
+        var prDir = Path.Combine(_tempDir, "pr-42");
+        Assert.True(Directory.Exists(prDir));
+        var files = Directory.GetFiles(prDir);
+        Assert.Single(files);
+    }
+
+    [Fact]
+    public async Task WritePromptAsync_FileNameMatchesFormat()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", "hello", CancellationToken.None);
+
+        var file = Directory.GetFiles(Path.Combine(_tempDir, "pr-42")).Single();
+        var name = Path.GetFileName(file);
+        // Format: yyyyMMdd-HHmmss-fff-NNN-kind-role.md
+        Assert.Matches(@"^\d{8}-\d{6}-\d{3}-\d{3}-page-1-review-prompt\.md$", name);
+    }
+
+    [Fact]
+    public async Task WritePromptAsync_ContentIsByteIdentical()
+    {
+        var writer = CreateWriter();
+        const string content = "Line 1\nLine 2\n=== src/Foo.cs ===\n@@ -1 +1 @@\n-old\n+new";
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", content, CancellationToken.None);
+
+        var file = Directory.GetFiles(Path.Combine(_tempDir, "pr-42")).Single();
+        var readBack = await File.ReadAllTextAsync(file);
+        Assert.Equal(content, readBack);
+    }
+
+    [Fact]
+    public async Task WriteResponseAsync_AfterPrompt_CreatesSecondFileWithIncrementedSeq()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", "p", CancellationToken.None);
+        await writer.WriteResponseAsync("pr:42", "page-1-review", "r", CancellationToken.None);
+
+        var files = Directory.GetFiles(Path.Combine(_tempDir, "pr-42")).Select(Path.GetFileName).OrderBy(n => n).ToArray();
+        Assert.Equal(2, files.Length);
+        Assert.EndsWith("-001-page-1-review-prompt.md", files[0]);
+        Assert.EndsWith("-002-page-1-review-response.md", files[1]);
+    }
+
+    [Fact]
+    public async Task MultipleWrites_SameKey_AllLandInOneSubdirectory()
+    {
+        var writer = CreateWriter();
+
+        for (var i = 1; i <= 5; i++)
+            await writer.WritePromptAsync("pr:42", $"page-{i}-review", $"p{i}", CancellationToken.None);
+
+        var prDir = Path.Combine(_tempDir, "pr-42");
+        var files = Directory.GetFiles(prDir);
+        Assert.Equal(5, files.Length);
+        // No sibling pr-42_* directories
+        var allDirs = Directory.GetDirectories(_tempDir);
+        Assert.Single(allDirs);
+    }
+
+    [Fact]
+    public async Task MultipleWrites_DifferentKeys_GetSeparateSubdirectories()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", "a", CancellationToken.None);
+        await writer.WritePromptAsync("pr:99", "page-1-review", "b", CancellationToken.None);
+        await writer.WritePromptAsync("local:staged:/repo", "page-1-review", "c", CancellationToken.None);
+
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "pr-42")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "pr-99")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "local-staged-repo")));
+    }
+
+    [Fact]
+    public async Task IllegalCharsInReviewKey_Sanitized()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("pr:42", "page-1-review", "x", CancellationToken.None);
+
+        // No directory with a colon
+        Assert.False(Directory.Exists(Path.Combine(_tempDir, "pr:42")));
+        Assert.True(Directory.Exists(Path.Combine(_tempDir, "pr-42")));
+    }
+
+    [Fact]
+    public async Task PathTraversalInReviewKey_StaysUnderBase()
+    {
+        var writer = CreateWriter();
+
+        await writer.WritePromptAsync("../../etc/passwd", "page-1-review", "x", CancellationToken.None);
+
+        // Containment check: every file the writer produced must be under _tempDir.
+        var tempFullPath = Path.GetFullPath(_tempDir);
+        var allFiles = Directory.GetFiles(tempFullPath, "*", SearchOption.AllDirectories);
+        foreach (var f in allFiles)
+        {
+            var full = Path.GetFullPath(f);
+            Assert.StartsWith(tempFullPath, full, StringComparison.OrdinalIgnoreCase);
+        }
+        Assert.NotEmpty(allFiles);
+    }
+
+    [Fact]
+    public async Task ParallelWrites_100Threads_NoCollisionOrLostFile()
+    {
+        var writer = CreateWriter();
+
+        var tasks = Enumerable.Range(0, 100)
+            .Select(i => writer.WritePromptAsync("pr:42", $"page-{i}-review", $"p{i}", CancellationToken.None))
+            .ToArray();
+        await Task.WhenAll(tasks);
+
+        var files = Directory.GetFiles(Path.Combine(_tempDir, "pr-42"));
+        Assert.Equal(100, files.Length);
+        // All file names must be unique
+        Assert.Equal(100, files.Select(Path.GetFileName).Distinct().Count());
+    }
+
+    [Fact]
+    public async Task IOException_LoggedAndReturnsNormally()
+    {
+        // Delete the base directory, then attempt a write into a path that can't be created
+        // (simulate by creating a file at the same location as the expected subdirectory).
+        var logger = Substitute.For<ILogger<FileSystemCopilotInspectionWriter>>();
+        var writer = new FileSystemCopilotInspectionWriter(_tempDir, logger);
+
+        // Create a *file* at the spot where the PR subdirectory would land → CreateDirectory fails.
+        var conflictPath = Path.Combine(_tempDir, "pr-42");
+        File.WriteAllText(conflictPath, "block");
+
+        // Must not throw.
+        await writer.WritePromptAsync("pr:42", "page-1-review", "x", CancellationToken.None);
+
+        // A warning must have been logged.
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task Cancellation_PropagatesOperationCanceledException()
+    {
+        var writer = CreateWriter();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await writer.WritePromptAsync("pr:42", "page-1-review", "x", cts.Token));
+    }
+
+    // Sanitize() tests — verify the normalization pipeline directly.
+
+    [Theory]
+    [InlineData("pr:42", "pr-42")]
+    [InlineData("pr-42", "pr-42")]
+    [InlineData("local:staged:/repo/foo", "local-staged-repo-foo")]
+    [InlineData("", "review")]
+    [InlineData("///", "review")]
+    [InlineData(":::", "review")]
+    [InlineData("...", "review")]
+    [InlineData("-a-", "a")]
+    [InlineData("foo..bar", "foo..bar")] // dots inside are kept; only trimmed from ends
+    public void Sanitize_NormalizesExpectedCases(string input, string expected)
+    {
+        var actual = FileSystemCopilotInspectionWriter.Sanitize(input);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Sanitize_LongInput_CappedAt100Chars()
+    {
+        var longInput = new string('a', 200);
+        var result = FileSystemCopilotInspectionWriter.Sanitize(longInput);
+        Assert.Equal(100, result.Length);
+    }
+
+    // ─── Feature 022 US3 (T020) — retention ───────────────────────────────────────
+
+    /// <summary>
+    /// Polls until <paramref name="condition"/> is true or <paramref name="timeoutMs"/>
+    /// elapses. Used to wait for fire-and-forget cleanup without flaky fixed delays.
+    /// </summary>
+    private static async Task<bool> WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var start = Environment.TickCount;
+        while (Environment.TickCount - start < timeoutMs)
+        {
+            if (condition()) return true;
+            await Task.Delay(20);
+        }
+        return condition();
+    }
+
+    [Fact]
+    public async Task Cleanup_FileOlderThan24h_IsDeleted()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-1");
+        Directory.CreateDirectory(prDir);
+        var oldFile = Path.Combine(prDir, "20260412-000000-000-001-page-1-review-prompt.md");
+        await File.WriteAllTextAsync(oldFile, "old content");
+
+        // Constructing the writer kicks off cleanup.
+        _ = CreateWriter();
+
+        var deleted = await WaitForAsync(() => !File.Exists(oldFile));
+        Assert.True(deleted, "Old file should have been removed by cleanup");
+    }
+
+    [Fact]
+    public async Task Cleanup_FileYoungerThan24h_IsPreserved()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-2");
+        Directory.CreateDirectory(prDir);
+        var freshTs = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff");
+        var freshFile = Path.Combine(prDir, $"{freshTs}-001-page-1-review-prompt.md");
+        await File.WriteAllTextAsync(freshFile, "fresh content");
+
+        _ = CreateWriter();
+
+        // Wait briefly for cleanup to complete; assert file still exists.
+        await Task.Delay(300);
+        Assert.True(File.Exists(freshFile), "Fresh file should be preserved");
+    }
+
+    [Fact]
+    public async Task Cleanup_MixedAgesInSameSubdir_OldDeletedFreshKept()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-3");
+        Directory.CreateDirectory(prDir);
+        var oldFile = Path.Combine(prDir, "20260412-000000-000-001-page-1-review-prompt.md");
+        var freshTs = DateTime.UtcNow.ToString("yyyyMMdd-HHmmss-fff");
+        var freshFile = Path.Combine(prDir, $"{freshTs}-002-page-1-review-response.md");
+        await File.WriteAllTextAsync(oldFile, "old");
+        await File.WriteAllTextAsync(freshFile, "fresh");
+
+        _ = CreateWriter();
+
+        await WaitForAsync(() => !File.Exists(oldFile));
+        Assert.False(File.Exists(oldFile), "Old file should be removed");
+        Assert.True(File.Exists(freshFile), "Fresh file should be preserved");
+        Assert.True(Directory.Exists(prDir), "Subdir should remain because a fresh file is still inside");
+    }
+
+    [Fact]
+    public async Task Cleanup_AllFilesOldInSubdir_EmptySubdirRemoved()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-4");
+        Directory.CreateDirectory(prDir);
+        await File.WriteAllTextAsync(Path.Combine(prDir, "20260412-000000-000-001-prompt.md"), "old1");
+        await File.WriteAllTextAsync(Path.Combine(prDir, "20260412-000005-000-002-response.md"), "old2");
+
+        _ = CreateWriter();
+
+        var dirGone = await WaitForAsync(() => !Directory.Exists(prDir));
+        Assert.True(dirGone, "Empty subdir (after file removal) should be deleted");
+    }
+
+    [Fact]
+    public async Task Cleanup_FreshSubdir_PreservedEvenWhenInitiallyEmpty()
+    {
+        // This is the regression test for the race fix: a brand-new empty subdir created
+        // by the writer must NOT be deleted by cleanup.
+        var prDir = Path.Combine(_tempDir, "pr-5");
+        Directory.CreateDirectory(prDir);
+        // No files inside — simulates the moment after CreateDirectory but before WriteAllText.
+
+        _ = CreateWriter();
+
+        await Task.Delay(300);
+        Assert.True(Directory.Exists(prDir),
+            "Brand-new empty subdir (no prior files) must not be touched by cleanup");
+    }
+
+    [Fact]
+    public async Task Cleanup_UnparseableFileName_UsesCreationTime()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-6");
+        Directory.CreateDirectory(prDir);
+        var garbledFile = Path.Combine(prDir, "garbled-file-name-no-timestamp.md");
+        await File.WriteAllTextAsync(garbledFile, "x");
+        // Backdate the creation time to 48h ago.
+        File.SetCreationTimeUtc(garbledFile, DateTime.UtcNow.AddHours(-48));
+
+        _ = CreateWriter();
+
+        var deleted = await WaitForAsync(() => !File.Exists(garbledFile));
+        Assert.True(deleted, "Garbled-name file with old CreationTimeUtc should be removed");
+    }
+
+    [Fact]
+    public async Task Cleanup_OneFileLocked_OthersStillProcessed()
+    {
+        var prDir = Path.Combine(_tempDir, "pr-7");
+        Directory.CreateDirectory(prDir);
+        var lockedFile = Path.Combine(prDir, "20260412-000000-000-001-locked-prompt.md");
+        var deletableFile = Path.Combine(prDir, "20260412-000005-000-002-deletable-response.md");
+        await File.WriteAllTextAsync(lockedFile, "locked");
+        await File.WriteAllTextAsync(deletableFile, "free");
+
+        // Hold an exclusive handle on the locked file for the duration of cleanup.
+        using (var stream = File.Open(lockedFile, FileMode.Open, FileAccess.Read, FileShare.None))
+        {
+            _ = CreateWriter();
+            await WaitForAsync(() => !File.Exists(deletableFile));
+        }
+
+        Assert.True(File.Exists(lockedFile), "Locked file should remain (delete failed gracefully)");
+        Assert.False(File.Exists(deletableFile), "Adjacent deletable file should still have been processed");
+    }
+}

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriterTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriterTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
@@ -334,6 +335,11 @@ public class FileSystemCopilotInspectionWriterTests : IDisposable
     [Fact]
     public async Task Cleanup_OneFileLocked_OthersStillProcessed()
     {
+        // File locking with FileShare.None only prevents deletion on Windows.
+        // On Unix, unlink() removes the directory entry regardless of open handles.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
         var prDir = Path.Combine(_tempDir, "pr-7");
         Directory.CreateDirectory(prDir);
         var lockedFile = Path.Combine(prDir, "20260412-000000-000-001-locked-prompt.md");

--- a/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/NoOpCopilotInspectionWriterTests.cs
+++ b/REBUSS.Pure.Tests/Services/CopilotReview/Inspection/NoOpCopilotInspectionWriterTests.cs
@@ -1,0 +1,42 @@
+using REBUSS.Pure.Services.CopilotReview.Inspection;
+
+namespace REBUSS.Pure.Tests.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Tests for <see cref="NoOpCopilotInspectionWriter"/>. Feature 022. Verifies both methods
+/// are no-ops and return completed tasks without touching any resource.
+/// </summary>
+public class NoOpCopilotInspectionWriterTests
+{
+    [Fact]
+    public void WritePromptAsync_ReturnsCompletedTaskSynchronously()
+    {
+        var writer = new NoOpCopilotInspectionWriter();
+
+        var task = writer.WritePromptAsync("pr:42", "page-1-review", "anything", CancellationToken.None);
+
+        Assert.True(task.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public void WriteResponseAsync_ReturnsCompletedTaskSynchronously()
+    {
+        var writer = new NoOpCopilotInspectionWriter();
+
+        var task = writer.WriteResponseAsync("pr:42", "page-1-review", "anything", CancellationToken.None);
+
+        Assert.True(task.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task WritePromptAsync_ManyCalls_NoneThrow()
+    {
+        var writer = new NoOpCopilotInspectionWriter();
+
+        for (var i = 0; i < 100; i++)
+        {
+            await writer.WritePromptAsync($"pr:{i}", "page-1-review", "content", CancellationToken.None);
+            await writer.WriteResponseAsync($"pr:{i}", "page-1-review", "content", CancellationToken.None);
+        }
+    }
+}

--- a/REBUSS.Pure/Program.cs
+++ b/REBUSS.Pure/Program.cs
@@ -186,6 +186,25 @@ namespace REBUSS.Pure
             services.AddSingleton<ICopilotSessionFactory, CopilotSessionFactory>();
             services.AddSingleton<ICopilotAvailabilityDetector, CopilotAvailabilityDetector>();
             services.AddSingleton<ICopilotPageReviewer, CopilotPageReviewer>();
+
+            // Feature 022 — Copilot inspection (internal diagnostic, env-var gated).
+            // REBUSS_COPILOT_INSPECT=1|true|True registers the filesystem writer; any other
+            // value registers a no-op. Read once at DI composition time; restart to toggle.
+            var inspectEnabled = Environment.GetEnvironmentVariable("REBUSS_COPILOT_INSPECT")
+                is "1" or "true" or "True";
+            if (inspectEnabled)
+            {
+                services.AddSingleton<
+                    REBUSS.Pure.Services.CopilotReview.Inspection.ICopilotInspectionWriter,
+                    REBUSS.Pure.Services.CopilotReview.Inspection.FileSystemCopilotInspectionWriter>();
+            }
+            else
+            {
+                services.AddSingleton<
+                    REBUSS.Pure.Services.CopilotReview.Inspection.ICopilotInspectionWriter,
+                    REBUSS.Pure.Services.CopilotReview.Inspection.NoOpCopilotInspectionWriter>();
+            }
+
             services.AddSingleton<ICopilotReviewOrchestrator, CopilotReviewOrchestrator>();
             services.AddSingleton<CopilotReviewWaiter>();
 

--- a/REBUSS.Pure/Services/CopilotReview/CopilotPageReviewer.cs
+++ b/REBUSS.Pure/Services/CopilotReview/CopilotPageReviewer.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using REBUSS.Pure.Core.Models.CopilotReview;
 using REBUSS.Pure.Core.Services.CopilotReview;
+using REBUSS.Pure.Services.CopilotReview.Inspection;
 
 namespace REBUSS.Pure.Services.CopilotReview;
 
@@ -22,15 +23,18 @@ internal sealed class CopilotPageReviewer : ICopilotPageReviewer
     private readonly ICopilotSessionFactory _sessionFactory;
     private readonly IOptions<CopilotReviewOptions> _options;
     private readonly ILogger<CopilotPageReviewer> _logger;
+    private readonly ICopilotInspectionWriter _inspection;
 
     public CopilotPageReviewer(
         ICopilotSessionFactory sessionFactory,
         IOptions<CopilotReviewOptions> options,
-        ILogger<CopilotPageReviewer> logger)
+        ILogger<CopilotPageReviewer> logger,
+        ICopilotInspectionWriter inspection)
     {
         _sessionFactory = sessionFactory;
         _options = options;
         _logger = logger;
+        _inspection = inspection;
     }
 
     private const string PromptResourceName = "REBUSS.Pure.Services.CopilotReview.Prompts.copilot-page-review.md";
@@ -38,10 +42,12 @@ internal sealed class CopilotPageReviewer : ICopilotPageReviewer
     private static string? _cachedPromptTemplate;
 
     public async Task<CopilotPageReviewResult> ReviewPageAsync(
+        string reviewKey,
         int pageNumber,
         string enrichedPageContent,
         CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(reviewKey);
         ArgumentNullException.ThrowIfNull(enrichedPageContent);
 
         string prompt;
@@ -55,6 +61,12 @@ internal sealed class CopilotPageReviewer : ICopilotPageReviewer
             return CopilotPageReviewResult.Failure(
                 pageNumber, Array.Empty<string>(), $"prompt template load failed: {ex.Message}", 1);
         }
+
+        // Feature 022: capture the prompt that will be sent to Copilot. Fires only on the
+        // happy path — the inspection writer is a NoOp when the env var is unset, so this
+        // is effectively free when disabled.
+        var inspectionKind = $"page-{pageNumber}-review";
+        await _inspection.WritePromptAsync(reviewKey, inspectionKind, prompt, ct).ConfigureAwait(false);
 
         ICopilotSessionHandle? handle = null;
         try
@@ -91,6 +103,10 @@ internal sealed class CopilotPageReviewer : ICopilotPageReviewer
 
             await handle.SendAsync(prompt, ct).ConfigureAwait(false);
             var reviewText = await tcs.Task.WaitAsync(ct).ConfigureAwait(false);
+
+            // Feature 022: capture the response. Only on the happy path — failure paths
+            // (session error, empty response) fall to the catch blocks below.
+            await _inspection.WriteResponseAsync(reviewKey, inspectionKind, reviewText, ct).ConfigureAwait(false);
 
             return CopilotPageReviewResult.Success(pageNumber, reviewText, attemptsMade: 1);
         }

--- a/REBUSS.Pure/Services/CopilotReview/CopilotReviewOrchestrator.cs
+++ b/REBUSS.Pure/Services/CopilotReview/CopilotReviewOrchestrator.cs
@@ -235,7 +235,7 @@ internal sealed class CopilotReviewOrchestrator : ICopilotReviewOrchestrator
             CopilotPageReviewResult result;
             try
             {
-                result = await _pageReviewer.ReviewPageAsync(pageNumber, enrichedContent, ct).ConfigureAwait(false);
+                result = await _pageReviewer.ReviewPageAsync(job.ReviewKey, pageNumber, enrichedContent, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/REBUSS.Pure/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriter.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Inspection/FileSystemCopilotInspectionWriter.cs
@@ -1,0 +1,308 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace REBUSS.Pure.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Captures prompts and responses to files under a per-user local directory.
+/// Feature 022 (internal diagnostic). Env-var-gated at DI composition — when the gate is off,
+/// <see cref="NoOpCopilotInspectionWriter"/> is registered instead.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Directory layout: <c>{base}/{safeKey}/{yyyyMMdd-HHmmss-fff}-{seq:D3}-{kind}-{role}.md</c>.
+/// The per-PR subdirectory is reused across sessions — all material for a given review
+/// identifier accumulates in one place. File names carry per-write timestamp + sequence,
+/// guaranteeing uniqueness across parallel writes AND across process invocations.
+/// </para>
+/// <para>
+/// <b>Security audit (feature 022, T023 — 2026-04-14):</b> Grep-verified that the
+/// <c>content</c> parameter passed to <see cref="WritePromptAsync"/> /
+/// <see cref="WriteResponseAsync"/> flows only from (a) the review-prompt template + enriched
+/// page content assembled by <c>CopilotPageReviewer</c>, and (b) the Copilot response text.
+/// No auth material (<c>GitHubToken</c>, <c>REBUSS_COPILOT_TOKEN</c>, <c>Bearer</c>,
+/// <c>Authorization</c>, session IDs) is sourced from any call site. Patterns checked:
+/// <c>GitHubToken</c>, <c>REBUSS_COPILOT_TOKEN</c>, <c>Bearer\s</c>, <c>Authorization</c>,
+/// <c>_sessionId</c>, <c>Cookie</c>, <c>ApiKey</c>, <c>ClientSecret</c>, <c>Password</c>.
+/// Zero matches in the Inspection/ directory. Network-API patterns (<c>HttpClient</c>,
+/// <c>WebClient</c>, <c>.SendAsync(</c>, <c>Socket</c>, <c>TcpClient</c>) also verified zero
+/// matches — the writer is filesystem-only, satisfying FR-014.
+/// </para>
+/// </remarks>
+internal sealed class FileSystemCopilotInspectionWriter : ICopilotInspectionWriter
+{
+    internal const string InspectionSubdirName = "copilot-inspection";
+    private const string TimestampFormat = "yyyyMMdd-HHmmss-fff";
+    private const int MaxSafeKeyLength = 100;
+
+    private static readonly TimeSpan RetentionMaxAge = TimeSpan.FromHours(24);
+
+    private readonly string _baseDirectory;
+    private readonly ILogger<FileSystemCopilotInspectionWriter> _logger;
+
+    // Per-safeKey mutable counter. Principle VI exception (feature 022 Complexity Tracking).
+    // Wrapper class is required because `Interlocked.Increment` needs a ref to a heap field;
+    // a value-type struct in a dictionary can't be atomically incremented in place.
+    private readonly ConcurrentDictionary<string, Counter> _counters = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Production constructor used by DI. Resolves the base directory via
+    /// <see cref="Environment.SpecialFolder.LocalApplicationData"/> and falls back to
+    /// <see cref="Path.GetTempPath"/> if the AppData path is not available (e.g., sandboxed
+    /// environments). Kicks off fire-and-forget retention cleanup.
+    /// </summary>
+    public FileSystemCopilotInspectionWriter(ILogger<FileSystemCopilotInspectionWriter> logger)
+        : this(ResolveBaseDirectory(logger), logger)
+    {
+    }
+
+    /// <summary>
+    /// Test constructor — accepts an explicit base directory so tests can point at a temp dir
+    /// and never touch real <c>%LOCALAPPDATA%</c>. Feature 022 tests use this exclusively.
+    /// </summary>
+    internal FileSystemCopilotInspectionWriter(
+        string baseDirectory,
+        ILogger<FileSystemCopilotInspectionWriter> logger)
+    {
+        _baseDirectory = baseDirectory;
+        _logger = logger;
+
+        try
+        {
+            Directory.CreateDirectory(_baseDirectory);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to create Copilot inspection base directory {BaseDir}; writes will log warnings",
+                _baseDirectory);
+        }
+
+        // Fire-and-forget retention. Must not block DI composition.
+        _ = Task.Run(() => CleanupAsync(_baseDirectory, RetentionMaxAge));
+    }
+
+    public Task WritePromptAsync(string reviewKey, string kind, string content, CancellationToken ct)
+        => WriteAsync(reviewKey, kind, role: "prompt", content, ct);
+
+    public Task WriteResponseAsync(string reviewKey, string kind, string content, CancellationToken ct)
+        => WriteAsync(reviewKey, kind, role: "response", content, ct);
+
+    private async Task WriteAsync(string reviewKey, string kind, string role, string content, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+
+        var safeKey = Sanitize(reviewKey);
+        var dir = Path.Combine(_baseDirectory, safeKey);
+
+        string name = "";
+        try
+        {
+            Directory.CreateDirectory(dir); // idempotent
+
+            var counter = _counters.GetOrAdd(safeKey, _ => new Counter());
+            var seq = Interlocked.Increment(ref counter.Value);
+            var ts = DateTime.UtcNow.ToString(TimestampFormat, CultureInfo.InvariantCulture);
+            var safeKind = Sanitize(kind);
+            name = $"{ts}-{seq:D3}-{safeKind}-{role}.md";
+            var fullPath = Path.Combine(dir, name);
+
+            await File.WriteAllTextAsync(fullPath, content, Encoding.UTF8, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Copilot inspection write failed for {SafeKey}/{File}", safeKey, name);
+        }
+    }
+
+    /// <summary>
+    /// Normalizes a caller-supplied identifier into a filesystem-safe form. Pipeline per
+    /// research.md Decision 3: colon-to-dash, invalid-char-to-dash, collapse runs of dashes,
+    /// trim leading/trailing dashes and dots, fallback to <c>"review"</c> if empty, cap length.
+    /// </summary>
+    internal static string Sanitize(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return "review";
+
+        var invalid = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(input.Length);
+        foreach (var ch in input)
+        {
+            if (ch == ':')
+                sb.Append('-');
+            else if (Array.IndexOf(invalid, ch) >= 0)
+                sb.Append('-');
+            else
+                sb.Append(ch);
+        }
+
+        // Collapse runs of '-' into one.
+        var raw = sb.ToString();
+        var collapsed = new StringBuilder(raw.Length);
+        var prevDash = false;
+        foreach (var ch in raw)
+        {
+            if (ch == '-')
+            {
+                if (!prevDash) collapsed.Append('-');
+                prevDash = true;
+            }
+            else
+            {
+                collapsed.Append(ch);
+                prevDash = false;
+            }
+        }
+
+        var trimmed = collapsed.ToString().Trim('-', '.');
+        if (trimmed.Length == 0)
+            return "review";
+
+        if (trimmed.Length > MaxSafeKeyLength)
+            trimmed = trimmed[..MaxSafeKeyLength];
+
+        return trimmed;
+    }
+
+    /// <summary>
+    /// Resolves the base directory: AppData local → Path.GetTempPath() fallback. Always logs
+    /// which path was chosen so maintainers can locate captured material.
+    /// </summary>
+    private static string ResolveBaseDirectory(ILogger<FileSystemCopilotInspectionWriter> logger)
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        if (!string.IsNullOrWhiteSpace(appData))
+            return Path.Combine(appData, "REBUSS.Pure", InspectionSubdirName);
+
+        var tempBased = Path.Combine(Path.GetTempPath(), "REBUSS.Pure", InspectionSubdirName);
+        logger.LogWarning(
+            "LocalApplicationData unavailable; falling back to temp path {Path} for Copilot inspection",
+            tempBased);
+        return tempBased;
+    }
+
+    /// <summary>
+    /// Per-file retention sweep. Deletes files older than <paramref name="maxAge"/>, then
+    /// removes any per-PR subdirectory that became empty. One file or one dir's failure never
+    /// aborts the sweep — all exceptions are caught per-item and logged at Warning.
+    /// </summary>
+    private Task CleanupAsync(string baseDir, TimeSpan maxAge)
+    {
+        var deletedFiles = 0;
+        var deletedDirs = 0;
+
+        // Track which dirs we actually removed files from. Only those become candidates
+        // for empty-dir removal — this avoids racing with concurrent writes that may have
+        // just created an empty subdir but haven't written its first file yet.
+        var dirsWithDeletions = new HashSet<string>(StringComparer.Ordinal);
+
+        try
+        {
+            if (!Directory.Exists(baseDir))
+                return Task.CompletedTask;
+
+            var now = DateTime.UtcNow;
+
+            foreach (var prDir in Directory.EnumerateDirectories(baseDir))
+            {
+                try
+                {
+                    foreach (var file in Directory.EnumerateFiles(prDir))
+                    {
+                        try
+                        {
+                            var fileTime = ParseLeadingTimestamp(Path.GetFileName(file))
+                                ?? new FileInfo(file).CreationTimeUtc;
+
+                            if (now - fileTime > maxAge)
+                            {
+                                File.Delete(file);
+                                deletedFiles++;
+                                dirsWithDeletions.Add(prDir);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogWarning(ex,
+                                "Copilot inspection cleanup: failed to evaluate/delete {File}", file);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Copilot inspection cleanup: failed enumerating files under {Dir}", prDir);
+                }
+            }
+
+            // Second pass: only consider dirs we removed files from, and only delete if
+            // they're empty now. Brand-new dirs that the writer just created (no prior
+            // contents → no deletions here) are left alone.
+            foreach (var prDir in dirsWithDeletions)
+            {
+                try
+                {
+                    if (Directory.Exists(prDir) && !Directory.EnumerateFileSystemEntries(prDir).Any())
+                    {
+                        Directory.Delete(prDir);
+                        deletedDirs++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Copilot inspection cleanup: failed removing empty dir {Dir}", prDir);
+                }
+            }
+
+            _logger.LogDebug(
+                "Copilot inspection cleanup: {Files} files, {Dirs} empty dirs removed from {Base}",
+                deletedFiles, deletedDirs, baseDir);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Copilot inspection cleanup top-level failure under {Base}; proceeding", baseDir);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Parses the leading <c>yyyyMMdd-HHmmss-fff</c> (19 chars) from a filename.
+    /// Returns <c>null</c> when the prefix is not a valid timestamp — caller falls back to
+    /// <see cref="FileInfo.CreationTimeUtc"/>.
+    /// </summary>
+    private static DateTime? ParseLeadingTimestamp(string fileName)
+    {
+        if (fileName.Length < TimestampFormat.Length)
+            return null;
+
+        var prefix = fileName[..TimestampFormat.Length];
+        if (DateTime.TryParseExact(
+                prefix, TimestampFormat, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var dt))
+        {
+            return dt;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Mutable int wrapper so <see cref="Interlocked.Increment(ref int)"/> can operate on it.
+    /// Principle VI exception: per-safeKey in-memory counter, process-lifetime scope.
+    /// </summary>
+    private sealed class Counter
+    {
+        public int Value;
+    }
+}

--- a/REBUSS.Pure/Services/CopilotReview/Inspection/ICopilotInspectionWriter.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Inspection/ICopilotInspectionWriter.cs
@@ -1,0 +1,38 @@
+namespace REBUSS.Pure.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Internal diagnostic hook for capturing the prompts sent to and responses received from
+/// the Copilot review agent. Feature 022.
+/// </summary>
+/// <remarks>
+/// Contract:
+/// <list type="bullet">
+/// <item>Both methods MUST NOT throw on IO failure — errors are logged at Warning and swallowed.
+/// The feature is diagnostic; capture failures must never propagate to the review pipeline.</item>
+/// <item>Both methods MAY throw <see cref="OperationCanceledException"/> when
+/// <paramref name="ct"/> is canceled.</item>
+/// <item>Implementations MUST be safe for concurrent invocation across threads (parallel page
+/// reviews dispatch concurrent writes with the same <paramref name="reviewKey"/>).</item>
+/// <item>Implementations MUST sanitize <paramref name="reviewKey"/> before using it in any
+/// filesystem path — the key is opaque caller-supplied input and may contain characters that
+/// are illegal in path components.</item>
+/// <item>Implementations MUST NOT write authentication credentials, session tokens, or any
+/// security artifact into captured content. Content originates from review prompts/responses
+/// which are credential-free by upstream contract; implementations must not attempt to enrich
+/// it with any auth material.</item>
+/// </list>
+/// </remarks>
+internal interface ICopilotInspectionWriter
+{
+    /// <summary>Capture a prompt that was sent to the Copilot review agent.</summary>
+    /// <param name="reviewKey">Opaque review identifier from the orchestrator (e.g., <c>pr:42</c>).</param>
+    /// <param name="kind">Short step descriptor (e.g., <c>page-1-review</c>). Sanitized before use.</param>
+    /// <param name="content">Verbatim prompt text.</param>
+    Task WritePromptAsync(string reviewKey, string kind, string content, CancellationToken ct);
+
+    /// <summary>Capture a response received from the Copilot review agent.</summary>
+    /// <param name="reviewKey">Opaque review identifier from the orchestrator.</param>
+    /// <param name="kind">Short step descriptor — paired with the matching prompt's <paramref name="kind"/>.</param>
+    /// <param name="content">Verbatim response text.</param>
+    Task WriteResponseAsync(string reviewKey, string kind, string content, CancellationToken ct);
+}

--- a/REBUSS.Pure/Services/CopilotReview/Inspection/NoOpCopilotInspectionWriter.cs
+++ b/REBUSS.Pure/Services/CopilotReview/Inspection/NoOpCopilotInspectionWriter.cs
@@ -1,0 +1,15 @@
+namespace REBUSS.Pure.Services.CopilotReview.Inspection;
+
+/// <summary>
+/// Default <see cref="ICopilotInspectionWriter"/> used when the <c>REBUSS_COPILOT_INSPECT</c>
+/// environment variable is unset. Both methods return a completed task synchronously —
+/// zero runtime cost. Feature 022.
+/// </summary>
+internal sealed class NoOpCopilotInspectionWriter : ICopilotInspectionWriter
+{
+    public Task WritePromptAsync(string reviewKey, string kind, string content, CancellationToken ct)
+        => Task.CompletedTask;
+
+    public Task WriteResponseAsync(string reviewKey, string kind, string content, CancellationToken ct)
+        => Task.CompletedTask;
+}


### PR DESCRIPTION
Adds ICopilotInspectionWriter for capturing Copilot review prompts and responses to disk for internal diagnostics, gated by the REBUSS_COPILOT_INSPECT env var. Includes both a no-op and a filesystem implementation with retention and sanitization. Updates DI, CopilotPageReviewer, and orchestrator to support reviewKey propagation. Comprehensive tests and documentation included. No impact when disabled.